### PR TITLE
Support className attribute in custom components

### DIFF
--- a/components/common/Avatar/AvatarGroup.tsx
+++ b/components/common/Avatar/AvatarGroup.tsx
@@ -12,16 +12,16 @@ import { cleanClassName } from '../../../lib/utils'
 import classNames from 'classnames'
 
 export interface AvatarGroupProps
-  extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className'>> {
+  extends PropsWithChildren<ComponentProps<'div'>> {
   reversed?: boolean
 }
 
-export const AvatarGroup: FC<AvatarGroupProps> = ({ children, reversed, ...props }) => {
+export const AvatarGroup: FC<AvatarGroupProps> = ({ children, reversed, className, ...props }) => {
   const { avatar: theme } = useTheme().theme
   const cleanProps = cleanClassName(props)
 
   return (
-    <div className={classNames(theme.group, reversed && theme.reverse)} {...cleanProps}>
+    <div className={classNames(theme.group, reversed && theme.reverse, className)} {...cleanProps}>
       {children}
     </div>
   )

--- a/components/common/Avatar/index.tsx
+++ b/components/common/Avatar/index.tsx
@@ -23,7 +23,7 @@ import type { StatusTypes } from '../../../theme/Types'
 
 export type AvatarGroupProps = GroupProps
 
-export interface AvatarProps extends Omit<ComponentProps<'div'>, 'className' | 'placeholder'> {
+export interface AvatarProps extends Omit<ComponentProps<'div'>, 'placeholder'> {
   rounded?: 'base' | 'full'
   status?: StatusTypes
   src?: string
@@ -44,7 +44,8 @@ const AvatarComponent: FC<AvatarProps> = ({
   bordered,
   altText = 'Avatar image',
   size = 'base',
-  unoptimized
+  unoptimized,
+  className
 }) => {
   const { avatar: theme, status: statuses } = useTheme().theme
 
@@ -57,6 +58,7 @@ const AvatarComponent: FC<AvatarProps> = ({
         Placeholder && theme.placeholder.background,
         theme.rounded[rounded],
         bordered && theme.bordered,
+        className,
       )}
     >
       {src && (

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -14,8 +14,7 @@ import { ComponentPropsWithRef, forwardRef, ReactNode } from 'react'
 import classNames from 'classnames'
 import { useTheme } from '../../theme/Context'
 
-export interface ButtonProps
-  extends Omit<ComponentPropsWithRef<'button'>, 'className' | 'color' | 'style'> {
+export interface ButtonProps extends Omit<ComponentPropsWithRef<'button'>, 'color' | 'style'> {
   children: ReactNode
   size?: 'small' | 'base' | 'large'
   variant?: 'primary' | 'secondary' | 'white' | 'danger'
@@ -25,7 +24,7 @@ export interface ButtonProps
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    { children, size = 'base', variant = 'primary', fullWidth, fullHeight, ...props },
+    { children, size = 'base', variant = 'primary', fullWidth, fullHeight, className, ...props },
     ref,
   ): JSX.Element => {
     const { button: theme } = useTheme().theme
@@ -38,6 +37,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           size === 'small' ? theme.rounded.small : theme.rounded.base,
           fullWidth && theme.sizes.full_w,
           fullHeight && theme.sizes.full_h,
+          className,
         )}
         ref={ref}
         {...props}

--- a/components/common/Dropdown/index.tsx
+++ b/components/common/Dropdown/index.tsx
@@ -5,18 +5,18 @@ import { DropdownHeader } from './DropdownHeader'
 import { useTheme } from '../../../theme/Context'
 import classNames from 'classnames'
 
-export interface DropdownProps extends Omit<ComponentProps<'div'>, 'className'> {
+export interface DropdownProps extends ComponentProps<'div'> {
   items: ReactNode
   divider?: boolean
   position?: 'left' | 'right'
   size?: 'full'
 }
 
-const DropdownComponent: FC<DropdownProps> = ({ children, items, divider, position, size }) => {
+const DropdownComponent: FC<DropdownProps> = ({ children, items, divider, position, size, className }) => {
   const { dropdown: theme } = useTheme().theme
 
   return (
-    <Menu as='div' className={theme.base}>
+    <Menu as='div' className={classNames(theme.base, className)}>
       <Menu.Button as='div' className={classNames(size && theme.size[size])}>
         {children}
       </Menu.Button>

--- a/components/common/Modal/index.tsx
+++ b/components/common/Modal/index.tsx
@@ -16,8 +16,9 @@ import { cleanClassName } from '../../../lib/utils'
 import { ModalContent } from './ModalContent'
 import { ModalActions } from './ModalActions'
 import { Transition, Dialog } from '@headlessui/react'
+import classNames from 'classnames'
 
-export interface ModalProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className'>> {
+export interface ModalProps extends PropsWithChildren<ComponentProps<'div'>> {
   show?: boolean
   size?: 'base' | 'large'
   focus?: RefObject<HTMLElement>
@@ -30,6 +31,7 @@ const ModalComponent: FC<ModalProps> = ({
   size = 'base',
   focus = createRef(),
   onClose,
+  className,
   ...props
 }) => {
   const { modal: theme } = useTheme().theme
@@ -39,7 +41,7 @@ const ModalComponent: FC<ModalProps> = ({
     <Transition.Root show={show} as={Fragment}>
       <Dialog
         as='div'
-        className='relative z-10'
+        className={classNames('relative', 'z-10', className)}
         onClose={() => onClose()}
         initialFocus={focus && focus}
         {...cleanProps}

--- a/components/common/Switch.tsx
+++ b/components/common/Switch.tsx
@@ -18,9 +18,10 @@ export interface SwitchProps {
   changed?: (enabled: boolean) => void
   disabled?: boolean
   label?: string
+  className: string | undefined
 }
 
-export const Switch: FC<SwitchProps> = ({ changed, on, disabled, label }): JSX.Element => {
+export const Switch: FC<SwitchProps> = ({ changed, on, disabled, label, className }): JSX.Element => {
   const [enabled, setEnabled] = useState(on || false)
   const { switch: switchTheme } = useTheme().theme
   const backgroundOn = disabled ? switchTheme.off.indigo : switchTheme.on.indigo
@@ -32,7 +33,7 @@ export const Switch: FC<SwitchProps> = ({ changed, on, disabled, label }): JSX.E
 
   return (
     <HeadlessSwitch.Group>
-      <div className='w-fit flex items-center flex-row-reverse'>
+      <div className={classNames('w-fit ', 'flex', 'items-center', 'flex-row-reverse', className)}>
         {label && <HeadlessSwitch.Label className='ml-3 text-sm font-medium'>{label}</HeadlessSwitch.Label>}
         <HeadlessSwitch
           checked={enabled}

--- a/components/common/TextInput.tsx
+++ b/components/common/TextInput.tsx
@@ -20,7 +20,7 @@ import { useTheme } from '../../theme/Context'
 import classNames from 'classnames'
 
 export interface TextInputProps
-  extends Omit<ComponentProps<'input'>, 'ref' | 'color' | 'className' | 'size'> {
+  extends Omit<ComponentProps<'input'>, 'ref' | 'color' | 'size'> {
   label?: string
   placeholder: string
   icon?: FC<ComponentProps<'svg'>>
@@ -48,6 +48,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       squared,
       onIconClick,
       id,
+      className,
       ...props
     },
     ref,
@@ -55,7 +56,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     const cleanProps = cleanClassName(props)
     const { input: theme } = useTheme().theme
     return (
-      <div className='text-left w-full'>
+      <div className={classNames('text-left', 'w-full', className)}>
         {label && (
           <label className={theme.label} htmlFor={id}>
             {label}


### PR DESCRIPTION
This is necessary to add style classes to custom components. E.g. adding a `margin-bottom` to a `TextInput` component:
```
<TextInput className='mb-4' />
```