### PR TITLE
Fix dark theme switcher

### DIFF
--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -47,7 +47,10 @@ export const TopBar: FC<TopBarProps> = ({ openMobileCb }) => {
   }
 
   const toggleDarkTheme = () => {
-    if (theme === 'dark') {
+    if (
+      theme === 'dark' ||
+      (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+    ) {
       setTheme('light')
     } else {
       setTheme('dark')
@@ -65,8 +68,19 @@ export const TopBar: FC<TopBarProps> = ({ openMobileCb }) => {
           </span>
         </Dropdown.Header>
       </div>
-      <Dropdown.Item icon={theme === 'dark' ? faSun : faMoon} onClick={toggleDarkTheme}>
-        {theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+      <Dropdown.Item
+        icon={
+          theme === 'dark' ||
+          (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+            ? faSun
+            : faMoon
+        }
+        onClick={toggleDarkTheme}
+      >
+        {theme === 'dark' ||
+        (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+          ? 'Switch to light theme'
+          : 'Switch to dark theme'}
       </Dropdown.Item>
       <Dropdown.Item icon={faArrowRightFromBracket} onClick={doLogout}>
         Logout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-app",
+  "name": "nethvoice-cti",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-app",
+      "name": "nethvoice-cti",
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "nethvoice-cti",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -25,7 +25,7 @@ export default function Login() {
   )
   let errorAlert = onError ? (
     <div className='relative w-full'>
-      <div className='absolute alertLogin w-full'>
+      <div className='absolute -bottom-[104px] w-full'>
         <InlineNotification type='error' title='Login Failed'>
           <p>{messageError}</p>
         </InlineNotification>

--- a/pages/phonebook.tsx
+++ b/pages/phonebook.tsx
@@ -313,7 +313,7 @@ const Phonebook: NextPage = () => {
         {/* pagination */}
         {!phonebookError && !!phonebook?.rows?.length && (
           <nav
-            className='flex items-center justify-between border-t px-0 py-4 border-gray-100 bg-gray-100 dark:border-gray-800 dark:bg-gray-800'
+            className='flex items-center justify-between border-t px-0 py-4 mb-8 border-gray-100 bg-gray-100 dark:border-gray-800 dark:bg-gray-800'
             aria-label='Pagination'
           >
             <div className='hidden sm:block'>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,7 +18,7 @@
     @apply h-full overflow-hidden;
   }
   #__next {
-    @apply h-full
+    @apply h-full;
   }
 }
 
@@ -26,8 +26,4 @@
   position: fixed;
   right: 18px !important;
   animation-duration: 1s;
-}
-
-.alertLogin{
-  bottom: -160px !important;
 }


### PR DESCRIPTION
On a system where dark mode is preferred by default, the quick theme switcher in the account menu now shows the proper menu item "Switch to light theme".
Before this fix, the dark theme was used but the menu item was showing "Switch to dark theme"

Other changes:
- Fix app name in `package.json` and `package-lock.json`
- Minor style fixes to login and phonebook