### PR TITLE
Enhance operators page

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -20,7 +20,7 @@ import { useTheme } from '../../theme/Context'
 export interface ButtonProps extends Omit<ComponentPropsWithRef<'button'>, 'color' | 'style'> {
   children: ReactNode
   size?: 'small' | 'base' | 'large'
-  variant?: 'primary' | 'secondary' | 'white' | 'danger'
+  variant?: 'primary' | 'secondary' | 'white' | 'ghost' | 'danger'
   fullWidth?: boolean
   fullHeight?: boolean
   disabled?: boolean

--- a/components/island/Island.tsx
+++ b/components/island/Island.tsx
@@ -16,7 +16,7 @@ export function Island() {
   useEffect(() => {
     // Create the configuration for the PhoneIsland
     if (!firstRender) {
-      const webRTCExtension = currentUser.endpoints.extension.find((el) => el.type === 'webrtc')
+      const webRTCExtension = currentUser.endpoints.extension.find((el: any) => el.type === 'webrtc')
       if (auth.token && currentUser.username && webRTCExtension) {
         setConfig(
           newIslandConfig({

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { FC, ReactNode, useState, useEffect } from 'react'
-import { NavBar, TopBar, MobileNavBar, SideBar, SideDrawer } from '.'
+import { NavBar, TopBar, MobileNavBar, SpeedDial, SideDrawer } from '.'
 import { navItems, NavItemsProps } from '../../config/routes'
 import { useRouter } from 'next/router'
 import { getUserInfo } from '../../services/user'
@@ -82,7 +82,7 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
             </section>
           </main>
           {/* Secondary column (hidden on smaller screens) */}
-          <SideBar />
+          <SpeedDial />
           <SideDrawer
             isShown={sideDrawer.isShown}
             contentType={sideDrawer.contentType}

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -47,6 +47,7 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
           mainextension: userInfo.data.endpoints.mainextension[0].id,
           mainPresence: userInfo.data.mainPresence,
           endpoints: userInfo.data.endpoints,
+          avatar: userInfo.data.settings.avatar
         })
       }
     }

--- a/components/layout/MobileNavBar.tsx
+++ b/components/layout/MobileNavBar.tsx
@@ -83,7 +83,7 @@ export const MobileNavBar: FC<MobileNavBarProps> = ({ closeMobileMenu, show, ite
                   <Image
                     className='h-8 w-auto'
                     src='https://tailwindui.com/img/logos/mark.svg?color=white'
-                    alt='Your Company'
+                    alt='logo'
                     unoptimized={true}
                     width={37.6}
                     height={32}

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -28,7 +28,7 @@ export const NavBar: FC<NavBarProps> = ({ items }) => {
           <Image
             className='h-8 w-auto'
             src='https://tailwindui.com/img/logos/mark.svg?color=white'
-            alt='Your Company'
+            alt='logo'
             unoptimized={true}
             width={37.6}
             height={32}

--- a/components/layout/SideBar.tsx
+++ b/components/layout/SideBar.tsx
@@ -97,6 +97,10 @@ export const SideBar = () => {
     }
   }
 
+  const callSpeedDial = (speedDial: any) => {
+    console.log('call speed dial', speedDial.speeddial_num) ////
+  }
+
   // The dropdown items for every speed dial element
   const getItemsMenu = (speedDial: any) => (
     <>
@@ -186,14 +190,19 @@ export const SideBar = () => {
                           <p className='truncate text-sm font-medium text-gray-900 dark:text-gray-100'>
                             {speedDial.name}
                           </p>
-                          <div className='truncate text-sm cursor-pointer mt-1 text-primary dark:text-primary'>
+                          <div className='truncate text-sm mt-1 text-primary dark:text-primary'>
                             <div className='flex items-center'>
                               <FontAwesomeIcon
                                 icon={faPhone}
                                 className='mr-1.5 h-4 w-4 flex-shrink-0 text-gray-400 dark:text-gray-500'
                                 aria-hidden='true'
                               />
-                              <span className='hover:underline'>{speedDial.speeddial_num}</span>
+                              <span
+                                className='cursor-pointer hover:underline'
+                                onClick={() => callSpeedDial(speedDial)}
+                              >
+                                {speedDial.speeddial_num}
+                              </span>
                             </div>
                           </div>
                         </div>
@@ -201,7 +210,7 @@ export const SideBar = () => {
                       <div className='flex gap-2'>
                         {/* Actions */}
                         <Dropdown items={getItemsMenu(speedDial)} position='left'>
-                          <Button variant='white'>
+                          <Button variant='ghost'>
                             <FontAwesomeIcon icon={faEllipsisVertical} className='h-4 w-4' />
                             <span className='sr-only'>Open speed dial menu</span>
                           </Button>

--- a/components/layout/SpeedDial.tsx
+++ b/components/layout/SpeedDial.tsx
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 /**
- * The SideBar component
+ * The SpeedDial component
  *
  * @return The fixed right bar with speed dials as the default
  */
 
 import type { SpeedDialType } from '../../services/types'
 import { useState, useEffect, useRef, MutableRefObject } from 'react'
-import { Button, Avatar, Modal, Dropdown, InlineNotification, EmptyState } from '../common/'
+import { Button, Avatar, Modal, Dropdown, InlineNotification, EmptyState } from '../common'
 import { deleteSpeedDial, getSpeedDials } from '../../services/phonebook'
 import {
   sortSpeedDials,
@@ -29,7 +29,7 @@ import {
   faBolt,
 } from '@fortawesome/free-solid-svg-icons'
 
-export const SideBar = () => {
+export const SpeedDial = () => {
   // The state for the delete modal
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false)
   // The state for the speed dials list

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -31,7 +31,9 @@ interface TopBarProps {
 
 export const TopBar: FC<TopBarProps> = ({ openMobileCb }) => {
   const router = useRouter()
-  const { name, mainextension, mainPresence } = useSelector((state: RootState) => state.user)
+  const { name, mainextension, mainPresence, avatar } = useSelector(
+    (state: RootState) => state.user,
+  )
   const { theme } = useSelector((state: RootState) => state.darkTheme)
   const auth = useSelector((state: RootState) => state.authentication)
 
@@ -134,7 +136,8 @@ export const TopBar: FC<TopBarProps> = ({ openMobileCb }) => {
               <span className='sr-only'>Open user menu</span>
               <Avatar
                 rounded='full'
-                src='https://images.unsplash.com/photo-1567532939604-b6b5b0db2604?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80'
+                src={avatar}
+                placeholderType='person'
                 size='small'
                 status={mainPresence || 'offline'}
               />

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -135,7 +135,6 @@ export const TopBar: FC<TopBarProps> = ({ openMobileCb }) => {
               <Avatar
                 rounded='full'
                 src='https://images.unsplash.com/photo-1567532939604-b6b5b0db2604?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80'
-                unoptimized={true}
                 size='small'
                 status={mainPresence || 'offline'}
               />

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 export * from './NavBar'
-export * from './SideBar'
+export * from './SpeedDial'
 export * from './SideDrawer'
 export * from './TopBar'
 export * from './MobileNavBar'

--- a/components/operators/Filter.tsx
+++ b/components/operators/Filter.tsx
@@ -775,7 +775,6 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                           {groupLabel}
                         </span>
                       </span>
-                      {/* //// todo active filters */}
                     </div>
                   </div>
                   {/* status */}

--- a/components/operators/Filter.tsx
+++ b/components/operators/Filter.tsx
@@ -41,12 +41,22 @@ const statusFilter = {
   ],
 }
 
+const layoutFilter = {
+  id: 'layout',
+  name: 'Layout',
+  options: [
+    { value: 'standard', label: 'Standard' },
+    { value: 'compact', label: 'Compact' },
+  ],
+}
+
 export interface FilterProps extends ComponentPropsWithRef<'div'> {
   groups: Array<string>
   updateTextFilter: Function
   updateGroupFilter: Function
   updateStatusFilter: Function
-  updateSortFilter: Function
+  updateSort: Function
+  updateLayout: Function
 }
 
 export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
@@ -55,9 +65,10 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       groups,
       className,
       updateTextFilter,
-      updateSortFilter,
       updateGroupFilter,
       updateStatusFilter,
+      updateSort,
+      updateLayout,
       ...props
     },
     ref,
@@ -127,7 +138,17 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       savePreference('operatorsSortBy', newSortBy, auth.username)
 
       // update operators (notify parent component)
-      updateSortFilter(newSortBy)
+      updateSort(newSortBy)
+    }
+
+    const [layout, setLayout]: any = useState('')
+    function changeLayout(event: any) {
+      const newLayout = event.target.id
+      setLayout(newLayout)
+      savePreference('operatorsLayout', newLayout, auth.username)
+
+      // update operators layout (notify parent component)
+      updateLayout(newLayout)
     }
 
     // retrieve filter values from local storage
@@ -137,10 +158,12 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       setGroup(filterValues.group)
       setStatus(filterValues.status)
       setSortBy(filterValues.sortBy)
+      setLayout(filterValues.layout)
 
       updateGroupFilter(filterValues.group)
       updateStatusFilter(filterValues.status)
-      updateSortFilter(filterValues.sortBy)
+      updateSort(filterValues.sortBy)
+      updateLayout(filterValues.layout)
     }, [])
 
     // group label
@@ -176,6 +199,17 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       }
     }, [sortBy])
 
+    // layout label
+
+    const [layoutLabel, setLayoutLabel] = useState('')
+    useEffect(() => {
+      const found = layoutFilter.options.find((option) => option.value === layout)
+
+      if (found) {
+        setLayoutLabel(found.label)
+      }
+    }, [layout])
+
     const resetFilters = () => {
       setTextFilter('')
       setGroup(DEFAULT_GROUP_FILTER)
@@ -189,7 +223,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       updateTextFilter('')
       updateGroupFilter(DEFAULT_GROUP_FILTER)
       updateStatusFilter(DEFAULT_STATUS_FILTER)
-      updateSortFilter(DEFAULT_SORT_BY)
+      updateSort(DEFAULT_SORT_BY)
     }
 
     return (
@@ -410,6 +444,59 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                           </>
                         )}
                       </Disclosure>
+                      {/* layout (mobile) */}
+                      <Disclosure
+                        as='div'
+                        key={layoutFilter.name}
+                        className='border-t px-4 py-6 border-gray-200 dark:border-gray-700'
+                      >
+                        {({ open }) => (
+                          <>
+                            <h3 className='-mx-2 -my-3 flow-root'>
+                              <Disclosure.Button className='flex w-full items-center justify-between px-2 py-3 text-sm bg-white text-gray-400 dark:bg-gray-900 dark:text-gray-500'>
+                                <span className='font-medium text-gray-900 dark:text-gray-100'>
+                                  {layoutFilter.name}
+                                </span>
+                                <span className='ml-6 flex items-center'>
+                                  <FontAwesomeIcon
+                                    icon={faChevronDown}
+                                    className={classNames(
+                                      open ? '-rotate-180' : 'rotate-0',
+                                      'h-3 w-3 transform',
+                                    )}
+                                    aria-hidden='true'
+                                  />
+                                </span>
+                              </Disclosure.Button>
+                            </h3>
+                            <Disclosure.Panel className='pt-6'>
+                              <fieldset>
+                                <legend className='sr-only'>{layoutFilter.name}</legend>
+                                <div className='space-y-4'>
+                                  {layoutFilter.options.map((option) => (
+                                    <div key={option.value} className='flex items-center'>
+                                      <input
+                                        id={option.value}
+                                        name={`filter-${layoutFilter.id}`}
+                                        type='radio'
+                                        defaultChecked={option.value === layout}
+                                        onChange={changeLayout}
+                                        className='h-4 w-4 border-gray-300 text-primary focus:ring-primaryLight dark:border-gray-600 dark:text-primary dark:focus:ring-primaryDark'
+                                      />
+                                      <label
+                                        htmlFor={option.value}
+                                        className='ml-3 block text-sm font-medium text-gray-700 dark:text-gray-200'
+                                      >
+                                        {option.label}
+                                      </label>
+                                    </div>
+                                  ))}
+                                </div>
+                              </fieldset>
+                            </Disclosure.Panel>
+                          </>
+                        )}
+                      </Disclosure>
                     </form>
                   </Dialog.Panel>
                 </Transition.Child>
@@ -604,6 +691,58 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                         </Popover.Panel>
                       </Transition>
                     </Popover>
+
+                    {/* layout filter */}
+                    <Popover
+                      as='div'
+                      key={layoutFilter.name}
+                      id={`desktop-menu-${layoutFilter.id}`}
+                      className='relative inline-block text-left'
+                    >
+                      <div>
+                        <Popover.Button className='group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'>
+                          <span>{layoutFilter.name}</span>
+                          <FontAwesomeIcon
+                            icon={faChevronDown}
+                            className='ml-2 h-3 w-3 flex-shrink-0 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400'
+                            aria-hidden='true'
+                          />
+                        </Popover.Button>
+                      </div>
+
+                      <Transition
+                        as={Fragment}
+                        enter='transition ease-out duration-100'
+                        enterFrom='transform opacity-0 scale-95'
+                        enterTo='transform opacity-100 scale-100'
+                        leave='transition ease-in duration-75'
+                        leaveFrom='transform opacity-100 scale-100'
+                        leaveTo='transform opacity-0 scale-95'
+                      >
+                        <Popover.Panel className='absolute right-0 z-10 mt-2 origin-top-right rounded-md p-4 shadow-2xl ring-1 ring-opacity-5 focus:outline-none bg-white ring-black dark:bg-gray-900 dark:ring-gray-600'>
+                          <form className='space-y-4'>
+                            {layoutFilter.options.map((option) => (
+                              <div key={option.value} className='flex items-center'>
+                                <input
+                                  id={option.value}
+                                  name={`filter-${layoutFilter.id}`}
+                                  type='radio'
+                                  defaultChecked={option.value === layout}
+                                  onChange={changeLayout}
+                                  className='h-4 w-4 border-gray-300 text-primary focus:ring-primaryLight dark:border-gray-600 dark:text-primary dark:focus:ring-primaryDark'
+                                />
+                                <label
+                                  htmlFor={option.value}
+                                  className='ml-3 block text-sm font-medium text-gray-700 dark:text-gray-200'
+                                >
+                                  {option.label}
+                                </label>
+                              </div>
+                            ))}
+                          </form>
+                        </Popover.Panel>
+                      </Transition>
+                    </Popover>
                   </Popover.Group>
 
                   <button
@@ -649,7 +788,6 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                           {statusLabel}
                         </span>
                       </span>
-                      {/* //// todo active filters */}
                     </div>
                   </div>
                   {/* sort by */}
@@ -664,6 +802,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                       </span>
                     </div>
                   </div>
+                  {/* separator */}
                   <div
                     aria-hidden='true'
                     className='hidden h-5 w-px sm:ml-4 sm:block bg-gray-300 dark:bg-gray-600'

--- a/components/operators/Filter.tsx
+++ b/components/operators/Filter.tsx
@@ -37,7 +37,7 @@ const statusFilter = {
     { value: 'available', label: 'Available' },
     { value: 'unavailable', label: 'Unavailable' },
     { value: 'offline', label: 'Offline' },
-    { value: 'allButOffline', label: 'All but offline' },
+    { value: 'allExceptOffline', label: 'All except offline' },
   ],
 }
 
@@ -121,6 +121,27 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       updateGroupFilter(newGroup)
     }
 
+    // text filter for groups
+
+    const [groupTextFilter, setGroupTextFilter] = useState('')
+    function changeGroupTextFilter(event: any) {
+      const newGroupTextFilter = event.target.value
+      setGroupTextFilter(newGroupTextFilter)
+    }
+
+    const [filteredGroups, setFilteredGroups] = useState([] as RadioButtonType[])
+
+    useEffect(() => {
+      const regex = /[^a-zA-Z0-9]/g
+      const queryText = groupTextFilter.replace(regex, '')
+
+      // filter group filter options that match
+      const filtered = groupFilter.options.filter((g) =>
+        new RegExp(queryText, 'i').test(g.label.replace(regex, '')),
+      )
+      setFilteredGroups(filtered)
+    }, [groupTextFilter, groupFilter.options])
+
     const [status, setStatus] = useState('')
     function changeStatus(event: any) {
       const newStatus = event.target.id
@@ -199,17 +220,6 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       }
     }, [sortBy])
 
-    // layout label
-
-    const [layoutLabel, setLayoutLabel] = useState('')
-    useEffect(() => {
-      const found = layoutFilter.options.find((option) => option.value === layout)
-
-      if (found) {
-        setLayoutLabel(found.label)
-      }
-    }, [layout])
-
     const resetFilters = () => {
       setTextFilter('')
       setGroup(DEFAULT_GROUP_FILTER)
@@ -271,7 +281,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
 
                     {/* Filters (mobile) */}
                     <form className='mt-4'>
-                      {/* groupFilter filter (mobile) */}
+                      {/* group filter (mobile) */}
                       <Disclosure
                         as='div'
                         key={groupFilter.name}
@@ -300,7 +310,19 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                               <fieldset>
                                 <legend className='sr-only'>{groupFilter.name}</legend>
                                 <div className='space-y-4'>
-                                  {groupFilter.options.map((option) => (
+                                  <TextInput
+                                    placeholder='Filter groups'
+                                    value={groupTextFilter}
+                                    onChange={changeGroupTextFilter}
+                                    autoFocus
+                                    className='min-w-[8rem]'
+                                  />
+                                  {!filteredGroups.length && (
+                                    <div className='text-sm text-gray-500 dark:text-gray-400'>
+                                      <span>No group</span>
+                                    </div>
+                                  )}
+                                  {filteredGroups.map((option) => (
                                     <div key={option.value}>
                                       {option.value.startsWith('divider') ? (
                                         <div className='relative'>
@@ -551,7 +573,19 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                       >
                         <Popover.Panel className='absolute right-0 z-10 mt-2 origin-top-right rounded-md p-4 shadow-2xl ring-1 ring-opacity-5 focus:outline-none bg-white ring-black dark:bg-gray-900 dark:ring-gray-700'>
                           <form className='space-y-4'>
-                            {groupFilter.options.map((option) => (
+                            <TextInput
+                              placeholder='Filter groups'
+                              value={groupTextFilter}
+                              onChange={changeGroupTextFilter}
+                              autoFocus
+                              className='min-w-[8rem]'
+                            />
+                            {!filteredGroups.length && (
+                              <div className='text-sm text-gray-500 dark:text-gray-400'>
+                                <span>No group</span>
+                              </div>
+                            )}
+                            {filteredGroups.map((option) => (
                               <div key={option.value}>
                                 {option.value.startsWith('divider') ? (
                                   <div className='relative'>

--- a/components/operators/Filter.tsx
+++ b/components/operators/Filter.tsx
@@ -520,14 +520,14 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                   />
                 </div>
 
-                <div className='flex'>
+                <div className='flex ml-4'>
                   <Popover.Group className='hidden sm:flex sm:items-baseline sm:space-x-8'>
                     {/* group filter */}
                     <Popover
                       as='div'
                       key={groupFilter.name}
                       id={`desktop-menu-${groupFilter.id}`}
-                      className='relative inline-block text-left'
+                      className='relative inline-block text-left shrink-0'
                     >
                       <div>
                         <Popover.Button className='group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'>
@@ -593,7 +593,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                       as='div'
                       key={statusFilter.name}
                       id={`desktop-menu-${statusFilter.id}`}
-                      className='relative inline-block text-left'
+                      className='relative inline-block text-left shrink-0'
                     >
                       <div>
                         <Popover.Button className='group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'>
@@ -645,7 +645,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                       as='div'
                       key={sortFilter.name}
                       id={`desktop-menu-${sortFilter.id}`}
-                      className='relative inline-block text-left'
+                      className='relative inline-block text-left shrink-0'
                     >
                       <div>
                         <Popover.Button className='group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'>
@@ -697,7 +697,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                       as='div'
                       key={layoutFilter.name}
                       id={`desktop-menu-${layoutFilter.id}`}
-                      className='relative inline-block text-left'
+                      className='relative inline-block text-left shrink-0'
                     >
                       <div>
                         <Popover.Button className='group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'>
@@ -747,7 +747,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
 
                   <button
                     type='button'
-                    className='inline-block text-sm font-medium sm:hidden ml-4 text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'
+                    className='inline-block text-sm font-medium sm:hidden text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'
                     onClick={() => setOpen(true)}
                   >
                     Filters

--- a/components/operators/Filter.tsx
+++ b/components/operators/Filter.tsx
@@ -1,13 +1,13 @@
 // Copyright (C) 2022 Nethesis S.r.l.
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { ComponentPropsWithRef, forwardRef } from 'react'
+import { ComponentPropsWithRef, forwardRef, useRef } from 'react'
 import classNames from 'classnames'
 import { TextInput } from '../common'
 import { Fragment, useState, useEffect } from 'react'
 import { Dialog, Disclosure, Popover, Transition } from '@headlessui/react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronDown, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { faChevronDown, faCircleXmark, faXmark } from '@fortawesome/free-solid-svg-icons'
 import { RadioButtonType } from '../../services/types'
 import {
   DEFAULT_GROUP_FILTER,
@@ -103,6 +103,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
     const [open, setOpen] = useState(false)
 
     const [textFilter, setTextFilter] = useState('')
+    const textFilterRef = useRef() as React.MutableRefObject<HTMLInputElement>
     function changeTextFilter(event: any) {
       const newTextFilter = event.target.value
       setTextFilter(newTextFilter)
@@ -124,6 +125,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
     // text filter for groups
 
     const [groupTextFilter, setGroupTextFilter] = useState('')
+    const groupTextFilterRef = useRef() as React.MutableRefObject<HTMLInputElement>
     function changeGroupTextFilter(event: any) {
       const newGroupTextFilter = event.target.value
       setGroupTextFilter(newGroupTextFilter)
@@ -236,6 +238,17 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       updateSort(DEFAULT_SORT_BY)
     }
 
+    const clearTextFilter = () => {
+      setTextFilter('')
+      updateTextFilter('')
+      textFilterRef.current.focus()
+    }
+
+    const clearGroupTextFilter = () => {
+      setGroupTextFilter('')
+      groupTextFilterRef.current.focus()
+    }
+
     return (
       <div className={classNames(className)} {...props}>
         <div className=''>
@@ -315,6 +328,10 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                                     value={groupTextFilter}
                                     onChange={changeGroupTextFilter}
                                     autoFocus
+                                    ref={groupTextFilterRef}
+                                    icon={faCircleXmark}
+                                    onIconClick={() => clearGroupTextFilter()}
+                                    trailingIcon={true}
                                     className='min-w-[8rem]'
                                   />
                                   {!filteredGroups.length && (
@@ -539,6 +556,10 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                     className='max-w-sm'
                     value={textFilter}
                     onChange={changeTextFilter}
+                    ref={textFilterRef}
+                    icon={faCircleXmark}
+                    onIconClick={() => clearTextFilter()}
+                    trailingIcon={true}
                   />
                 </div>
 
@@ -578,7 +599,11 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                               value={groupTextFilter}
                               onChange={changeGroupTextFilter}
                               autoFocus
-                              className='min-w-[8rem]'
+                              ref={groupTextFilterRef}
+                              icon={faCircleXmark}
+                              onIconClick={() => clearGroupTextFilter()}
+                              trailingIcon={true}
+                              className='min-w-[10rem]'
                             />
                             {!filteredGroups.length && (
                               <div className='text-sm text-gray-500 dark:text-gray-400'>

--- a/components/operators/OperatorStatusBadge.tsx
+++ b/components/operators/OperatorStatusBadge.tsx
@@ -32,10 +32,10 @@ export const OperatorStatusBadge: FC<OperatorStatusBadgeProps> = ({
     setCallable(callable && callEnabled)
   }, [operator, currentUsername, callEnabled])
 
-  const badgeClicked = () => {
+  const badgeClicked = (ev: any) => {
     if (isCallable && onCall) {
       // notify parent component
-      onCall(operator)
+      onCall(operator, ev)
     }
   }
 
@@ -66,7 +66,7 @@ export const OperatorStatusBadge: FC<OperatorStatusBadgeProps> = ({
               {/* phone icon */}
               <FontAwesomeIcon
                 icon={faPhone}
-                className='mr-2 h-4 w-4 flex-shrink-0'
+                className='mr-1.5 h-3 w-3 flex-shrink-0'
                 aria-hidden='true'
               />
               <span>{capitalize(operator.mainPresence)}</span>

--- a/components/operators/OperatorStatusBadge.tsx
+++ b/components/operators/OperatorStatusBadge.tsx
@@ -48,11 +48,7 @@ export const OperatorStatusBadge: FC<OperatorStatusBadgeProps> = ({
           size={size}
           onClick={badgeClicked}
           className={classNames(
-            isCallable
-              ? 'hover:bg-emerald-300 dark:hover:bg-emerald-900 cursor-pointer'
-              : callEnabled && !isCallable
-              ? 'cursor-not-allowed'
-              : 'cursor-default',
+            isCallable && 'hover:bg-emerald-300 dark:hover:bg-emerald-900 cursor-pointer',
           )}
         >
           {['incoming', 'ringing'].includes(operator.mainPresence) ? (

--- a/components/operators/OperatorStatusBadge.tsx
+++ b/components/operators/OperatorStatusBadge.tsx
@@ -53,10 +53,10 @@ export const OperatorStatusBadge: FC<OperatorStatusBadgeProps> = ({
               : 'cursor-not-allowed',
           )}
         >
-          {operator.mainPresence === 'incoming' ? (
+          {['incoming', 'ringing'].includes(operator.mainPresence) ? (
             <div className='flex items-center'>
               {/* ringing icon */}
-              <span className='incoming-loader mr-2'></span>
+              <span className='ringing-animation mr-2'></span>
               <span>{capitalize(operator.mainPresence)}</span>
             </div>
           ) : isCallable ? (

--- a/components/operators/OperatorStatusBadge.tsx
+++ b/components/operators/OperatorStatusBadge.tsx
@@ -50,7 +50,9 @@ export const OperatorStatusBadge: FC<OperatorStatusBadgeProps> = ({
           className={classNames(
             isCallable
               ? 'hover:bg-emerald-300 dark:hover:bg-emerald-900 cursor-pointer'
-              : 'cursor-not-allowed',
+              : callEnabled && !isCallable
+              ? 'cursor-not-allowed'
+              : 'cursor-default',
           )}
         >
           {['incoming', 'ringing'].includes(operator.mainPresence) ? (
@@ -70,7 +72,7 @@ export const OperatorStatusBadge: FC<OperatorStatusBadgeProps> = ({
               <span>{capitalize(operator.mainPresence)}</span>
             </div>
           ) : (
-            <span className='cursor-not-allowed'>{capitalize(operator.mainPresence)}</span>
+            <span>{capitalize(operator.mainPresence)}</span>
           )}
         </Badge>
       </div>

--- a/components/operators/ShowOperatorDrawerContent.tsx
+++ b/components/operators/ShowOperatorDrawerContent.tsx
@@ -3,15 +3,21 @@
 
 import { ComponentPropsWithRef, forwardRef, useState } from 'react'
 import classNames from 'classnames'
-import { Avatar, Button, IconSwitch } from '../common'
+import { Avatar, Button, Dropdown, IconSwitch } from '../common'
 import { useEffect } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
+  faCircle,
   faComment,
+  faEllipsisVertical,
   faEnvelope,
+  faHandPointUp,
   faMobileScreenButton,
   faPhone,
+  faPhoneSlash,
   faStar,
+  faTicket,
+  faUserSecret,
   faVideo,
 } from '@fortawesome/free-solid-svg-icons'
 import { OperatorStatusBadge } from './OperatorStatusBadge'
@@ -49,6 +55,16 @@ export const ShowOperatorDrawerContent = forwardRef<
     setFavorite(!isFavorite)
     reloadOperators()
   }
+
+  const getCallActionsMenu = () => (
+    <>
+      <Dropdown.Item icon={faTicket}>Book</Dropdown.Item>
+      <Dropdown.Item icon={faPhoneSlash}>Hangup</Dropdown.Item>
+      <Dropdown.Item icon={faUserSecret}>Spy</Dropdown.Item>
+      <Dropdown.Item icon={faHandPointUp}>Intrude</Dropdown.Item>
+      <Dropdown.Item icon={faCircle}>Record</Dropdown.Item>
+    </>
+  )
 
   return (
     <div className={classNames('p-1', className)} {...props}>
@@ -181,12 +197,19 @@ export const ShowOperatorDrawerContent = forwardRef<
           )}
         </dl>
       </div>
-      {/*  ongoing call info */}
-      {config.mainPresence === 'busy' && config.conversations?.length && (
+      {/* ongoing call info */}
+      {config.conversations?.length && (
         <div>
-          <h4 className='mt-6 text-md font-medium text-gray-700 dark:text-gray-200'>
-            Current call
-          </h4>
+          <div className='mt-6 flex items-end justify-between'>
+            <h4 className='text-md font-medium text-gray-700 dark:text-gray-200'>Current call</h4>
+            {/* ongoing call menu */}
+            <Dropdown items={getCallActionsMenu()} position='left'>
+              <Button variant='ghost'>
+                <FontAwesomeIcon icon={faEllipsisVertical} className='h-4 w-4' />
+                <span className='sr-only'>Open call actions menu</span>
+              </Button>
+            </Dropdown>
+          </div>
           <div className='mt-4 border-t border-gray-200 dark:border-gray-700'>
             <dl className='sm:divide-y sm:divide-gray-200 dark:sm:divide-gray-700'>
               {/*  interlocutor */}

--- a/components/operators/ShowOperatorDrawerContent.tsx
+++ b/components/operators/ShowOperatorDrawerContent.tsx
@@ -182,18 +182,38 @@ export const ShowOperatorDrawerContent = forwardRef<
         </dl>
       </div>
       {/*  ongoing call info */}
-      {config.mainPresence === 'busy' && (
+      {config.mainPresence === 'busy' && config.conversations?.length && (
         <div>
           <h4 className='mt-6 text-md font-medium text-gray-700 dark:text-gray-200'>
             Current call
           </h4>
           <div className='mt-4 border-t border-gray-200 dark:border-gray-700'>
             <dl className='sm:divide-y sm:divide-gray-200 dark:sm:divide-gray-700'>
+              {/*  interlocutor */}
+
               <div className='py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5'>
-                <dt className='text-sm font-medium text-gray-500 dark:text-gray-400'>Name</dt>
+                <dt className='text-sm font-medium text-gray-500 dark:text-gray-400'>
+                  Interlocutor
+                </dt>
                 <dd className='mt-1 text-sm text-gray-900 dark:text-gray-100 sm:col-span-2 sm:mt-0'>
+                  {config.conversations[0].counterpartName !==
+                    config.conversations[0].counterpartNum && (
+                    <div className='mb-1.5 flex items-center text-sm'>
+                      <span className='truncate'>
+                        {config.conversations[0].counterpartName || '-'}
+                      </span>
+                    </div>
+                  )}
+                  {/*  number */}
                   <div className='flex items-center text-sm'>
-                    <span className='truncate cursor-pointer'>-</span>
+                    <FontAwesomeIcon
+                      icon={faPhone}
+                      className='mr-2 h-4 w-4 flex-shrink-0 text-gray-400 dark:text-gray-500'
+                      aria-hidden='true'
+                    />
+                    <span className='truncate'>
+                      {config.conversations[0].counterpartNum || '-'}
+                    </span>
                   </div>
                 </dd>
               </div>
@@ -202,7 +222,7 @@ export const ShowOperatorDrawerContent = forwardRef<
                 <dt className='text-sm font-medium text-gray-500 dark:text-gray-400'>Direction</dt>
                 <dd className='mt-1 text-sm text-gray-900 dark:text-gray-100 sm:col-span-2 sm:mt-0'>
                   <div className='flex items-center text-sm'>
-                    <span className='truncate cursor-pointer'>-</span>
+                    <span className='truncate'>{config.conversations[0].direction}</span>
                   </div>
                 </dd>
               </div>
@@ -211,7 +231,7 @@ export const ShowOperatorDrawerContent = forwardRef<
                 <dt className='text-sm font-medium text-gray-500 dark:text-gray-400'>Duration</dt>
                 <dd className='mt-1 text-sm text-gray-900 dark:text-gray-100 sm:col-span-2 sm:mt-0'>
                   <div className='flex items-center text-sm'>
-                    <span className='truncate cursor-pointer'>-</span>
+                    <span className='truncate'>{config.conversations[0].duration}</span>
                   </div>
                 </dd>
               </div>

--- a/components/phonebook/Filter.tsx
+++ b/components/phonebook/Filter.tsx
@@ -35,11 +35,11 @@ const contactTypeFilter = {
 export interface FilterProps extends ComponentPropsWithRef<'div'> {
   updateTextFilter: Function
   updateContactTypeFilter: Function
-  updateSortFilter: Function
+  updateSort: Function
 }
 
 export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
-  ({ updateTextFilter, updateContactTypeFilter, updateSortFilter, className, ...props }, ref) => {
+  ({ updateTextFilter, updateContactTypeFilter, updateSort, className, ...props }, ref) => {
     const auth = useSelector((state: RootState) => state.authentication)
     const [open, setOpen] = useState(false)
 
@@ -69,7 +69,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       savePreference('phonebookSortBy', newSortBy, auth.username)
 
       // update phonebook (notify parent component)
-      updateSortFilter(newSortBy)
+      updateSort(newSortBy)
     }
 
     // contact type label
@@ -102,7 +102,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       setSortBy(filterValues.sortBy)
 
       updateContactTypeFilter(filterValues.contactType)
-      updateSortFilter(filterValues.sortBy)
+      updateSort(filterValues.sortBy)
     }, [])
 
     const resetFilters = () => {
@@ -115,7 +115,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       // notify parent component
       updateTextFilter('')
       updateContactTypeFilter(DEFAULT_CONTACT_TYPE_FILTER)
-      updateSortFilter(DEFAULT_SORT_BY)
+      updateSort(DEFAULT_SORT_BY)
     }
 
     return (

--- a/components/phonebook/Filter.tsx
+++ b/components/phonebook/Filter.tsx
@@ -1,13 +1,13 @@
 // Copyright (C) 2022 Nethesis S.r.l.
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { ComponentPropsWithRef, forwardRef } from 'react'
+import { ComponentPropsWithRef, forwardRef, useRef } from 'react'
 import classNames from 'classnames'
 import { TextInput } from '../common'
 import { Fragment, useState, useEffect } from 'react'
 import { Dialog, Disclosure, Popover, Transition } from '@headlessui/react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronDown, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { faChevronDown, faCircleXmark, faXmark } from '@fortawesome/free-solid-svg-icons'
 import { DEFAULT_CONTACT_TYPE_FILTER, DEFAULT_SORT_BY, getFilterValues } from '../../lib/phonebook'
 import { useSelector } from 'react-redux'
 import { RootState } from '../../store'
@@ -44,12 +44,19 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
     const [open, setOpen] = useState(false)
 
     const [textFilter, setTextFilter] = useState('')
+    const textFilterRef = useRef() as React.MutableRefObject<HTMLInputElement>
     function changeTextFilter(event: any) {
       const newTextFilter = event.target.value
       setTextFilter(newTextFilter)
 
       // update phonebook (notify parent component)
       updateTextFilter(newTextFilter)
+    }
+
+    const clearTextFilter = () => {
+      setTextFilter('')
+      updateTextFilter('')
+      textFilterRef.current.focus()
     }
 
     const [contactType, setContactType] = useState('all')
@@ -289,6 +296,10 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                     className='max-w-sm'
                     value={textFilter}
                     onChange={changeTextFilter}
+                    ref={textFilterRef}
+                    icon={faCircleXmark}
+                    onIconClick={() => clearTextFilter()}
+                    trailingIcon={true}
                   />
                 </div>
 

--- a/components/phonebook/Filter.tsx
+++ b/components/phonebook/Filter.tsx
@@ -292,14 +292,14 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                   />
                 </div>
 
-                <div className='flex'>
+                <div className='flex ml-4'>
                   <Popover.Group className='hidden sm:flex sm:items-baseline sm:space-x-8'>
                     {/* contact type filter */}
                     <Popover
                       as='div'
                       key={contactTypeFilter.name}
                       id={`desktop-menu-${contactTypeFilter.id}`}
-                      className='relative inline-block text-left'
+                      className='relative inline-block text-left shrink-0'
                     >
                       <div>
                         <Popover.Button className='group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'>
@@ -351,7 +351,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                       as='div'
                       key={sortFilter.name}
                       id={`desktop-menu-${sortFilter.id}`}
-                      className='relative inline-block text-left'
+                      className='relative inline-block text-left shrink-0'
                     >
                       <div>
                         <Popover.Button className='group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'>
@@ -401,7 +401,7 @@ export const Filter = forwardRef<HTMLButtonElement, FilterProps>(
 
                   <button
                     type='button'
-                    className='inline-block text-sm font-medium sm:hidden ml-4 text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'
+                    className='inline-block text-sm font-medium sm:hidden text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100'
                     onClick={() => setOpen(true)}
                   >
                     Filters

--- a/components/phonebook/ShowContactDrawerContent.tsx
+++ b/components/phonebook/ShowContactDrawerContent.tsx
@@ -135,7 +135,7 @@ export const ShowContactDrawerContent = forwardRef<
                 divider={true}
                 className='mr-1 mt-1'
               >
-                <Button variant='white'>
+                <Button variant='ghost'>
                   <FontAwesomeIcon icon={faEllipsisVertical} className='h-4 w-4' />
                   <span className='sr-only'>Open contact menu</span>
                 </Button>

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -43,6 +43,16 @@ export async function getGroups() {
   }
 }
 
+export async function getExtensions() {
+  try {
+    const { data } = await axios.get('/astproxy/extensions')
+    return data
+  } catch (error) {
+    handleNetworkError(error)
+    throw error
+  }
+}
+
 export function searchStringInOperator(operator: any, queryText: string) {
   const regex = /[^a-zA-Z0-9]/g
   queryText = queryText.replace(regex, '')

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -11,6 +11,7 @@ export const UNAVAILABLE_STATUSES = ['dnd', 'busy', 'incoming', 'offline']
 export const DEFAULT_GROUP_FILTER = 'all'
 export const DEFAULT_STATUS_FILTER = 'all'
 export const DEFAULT_SORT_BY = 'favorites'
+export const DEFAULT_LAYOUT = 'standard'
 
 export async function getUserEndpointsAll() {
   try {
@@ -154,5 +155,7 @@ export const getFilterValues = (currentUsername: string) => {
 
   const sortBy = loadPreference('operatorsSortBy', currentUsername) || DEFAULT_SORT_BY
 
-  return { group, status, sortBy }
+  const layout = loadPreference('operatorsLayout', currentUsername) || DEFAULT_LAYOUT
+
+  return { group, status, sortBy, layout }
 }

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -7,7 +7,7 @@ import { store } from '../store'
 import { loadPreference, savePreference } from './storage'
 
 export const AVAILABLE_STATUSES = ['online', 'cellphone', 'callforward', 'voicemail']
-export const UNAVAILABLE_STATUSES = ['dnd', 'busy', 'incoming']
+export const UNAVAILABLE_STATUSES = ['dnd', 'busy', 'incoming', 'ringing']
 export const DEFAULT_GROUP_FILTER = 'all'
 export const DEFAULT_STATUS_FILTER = 'all'
 export const DEFAULT_SORT_BY = 'favorites'
@@ -89,6 +89,7 @@ export const sortByOperatorStatus = (operator1: any, operator2: any) => {
     'callforward',
     'voicemail',
     'incoming',
+    'ringing',
     'busy',
     'dnd',
     'offline',

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -7,7 +7,7 @@ import { store } from '../store'
 import { loadPreference, savePreference } from './storage'
 
 export const AVAILABLE_STATUSES = ['online', 'cellphone', 'callforward', 'voicemail']
-export const UNAVAILABLE_STATUSES = ['dnd', 'busy', 'incoming', 'offline']
+export const UNAVAILABLE_STATUSES = ['dnd', 'busy', 'incoming']
 export const DEFAULT_GROUP_FILTER = 'all'
 export const DEFAULT_STATUS_FILTER = 'all'
 export const DEFAULT_SORT_BY = 'favorites'

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -116,8 +116,13 @@ export const sortByFavorite = (operator1: any, operator2: any) => {
   return 0
 }
 
-export const callOperator = (operator: any) => {
+export const callOperator = (operator: any, event: any = undefined) => {
   console.log('call operator', operator) ////
+
+  // stop propagation of click event
+  if (event) {
+    event.stopPropagation()
+  }
 }
 
 export const isOperatorCallable = (operator: any, currentUsername: string) => {

--- a/models/user.ts
+++ b/models/user.ts
@@ -19,6 +19,7 @@ interface DefaultState {
   mainextension: string
   mainPresence: StatusTypes
   endpoints: EndpointsTypes
+  avatar: string
 }
 
 const defaultState: DefaultState = {
@@ -34,6 +35,7 @@ const defaultState: DefaultState = {
     mainextension: [],
     voicemail: [],
   },
+  avatar: '',
 }
 
 export const user = createModel<RootModel>()({
@@ -45,6 +47,7 @@ export const user = createModel<RootModel>()({
       state.mainextension = payload.mainextension
       state.mainPresence = payload.mainPresence
       state.endpoints = payload.endpoints
+      state.avatar = payload.avatar
       return state
     },
     reset: () => {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -172,7 +172,7 @@ export default function Login() {
             src={Background}
             alt='Background image'
             layout='fill'
-            unoptimized={false}
+            unoptimized={true}
           />
         </div>
       </div>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -92,7 +92,7 @@ export default function Login() {
               <Image
                 className='mx-auto h-12 w-auto'
                 src={Logo}
-                alt='Your Company'
+                alt='logo'
                 width='100'
                 height='100'
                 unoptimized={true}

--- a/pages/operators.tsx
+++ b/pages/operators.tsx
@@ -379,7 +379,7 @@ const Operators: NextPage = () => {
                       <button
                         type='button'
                         onClick={() => openShowOperatorDrawer(operator)}
-                        className='group flex w-full items-center justify-between space-x-3 rounded-full border p-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 focus:ring-primary dark:focus:ring-primary'
+                        className='group flex w-full items-center justify-between space-x-3 rounded-full border p-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 focus:ring-primary dark:focus:ring-primary'
                       >
                         <span className='flex min-w-0 flex-1 items-center space-x-3'>
                           <span className='block flex-shrink-0'>

--- a/pages/operators.tsx
+++ b/pages/operators.tsx
@@ -147,6 +147,7 @@ const Operators: NextPage = () => {
           //     'callforward',
           //     'busy',
           //     'incoming',
+          //     'ringing',
           //     'offline',
           //   ]
           //   operator.mainPresence = statuses[i]

--- a/pages/operators.tsx
+++ b/pages/operators.tsx
@@ -346,12 +346,23 @@ const Operators: NextPage = () => {
                                   {operator.name}
                                 </h3>
                                 <div className='mt-3'>
-                                  <OperatorStatusBadge
-                                    operator={operator}
-                                    currentUsername={auth.username}
-                                    callEnabled={true}
-                                    onCall={callOperator}
-                                  />
+                                  <span className='block truncate mt-1 text-sm font-medium text-gray-500 dark:text-gray-500'>
+                                    {operator.mainPresence === 'busy' &&
+                                    operator.conversations?.length ? (
+                                      <Badge rounded='full' variant='busy' size='small'>
+                                        <span className='mr-1.5'>Busy</span>
+                                        {/* //// TODO format duration */}
+                                        <span>{operator.conversations[0].duration}</span>
+                                      </Badge>
+                                    ) : (
+                                      <OperatorStatusBadge
+                                        operator={operator}
+                                        currentUsername={auth.username}
+                                        callEnabled={true}
+                                        onCall={callOperator}
+                                      />
+                                    )}
+                                  </span>
                                 </div>
                               </div>
                             </div>
@@ -429,10 +440,7 @@ const Operators: NextPage = () => {
                               {operator.mainPresence === 'busy' &&
                               operator.conversations?.length ? (
                                 <Badge rounded='full' variant='busy' size='small'>
-                                  <span className='mr-3'>
-                                    {operator.conversations[0].counterpartName ||
-                                      operator.conversations[0].counterpartNum}
-                                  </span>
+                                  <span className='mr-1.5'>Busy</span>
                                   {/* //// TODO format duration */}
                                   <span>{operator.conversations[0].duration}</span>
                                 </Badge>

--- a/pages/operators.tsx
+++ b/pages/operators.tsx
@@ -98,7 +98,7 @@ const Operators: NextPage = () => {
         (statusFilter === 'available' && AVAILABLE_STATUSES.includes(op.mainPresence)) ||
         (statusFilter === 'unavailable' && UNAVAILABLE_STATUSES.includes(op.mainPresence)) ||
         (statusFilter === 'offline' && op.mainPresence === 'offline') ||
-        (statusFilter === 'allButOffline' && op.mainPresence !== 'offline')
+        (statusFilter === 'allExceptOffline' && op.mainPresence !== 'offline')
       )
     })
 

--- a/pages/operators.tsx
+++ b/pages/operators.tsx
@@ -404,7 +404,6 @@ const Operators: NextPage = () => {
                                   rounded='full'
                                   variant='busy'
                                   size='small'
-                                  className='cursor-not-allowed'
                                 >
                                   {/* //// TODO retrieve call information*/}
                                   <span className='mr-3'>Big Tech spa</span>

--- a/pages/operators.tsx
+++ b/pages/operators.tsx
@@ -347,10 +347,9 @@ const Operators: NextPage = () => {
                                 </h3>
                                 <div className='mt-3'>
                                   <span className='block truncate mt-1 text-sm font-medium text-gray-500 dark:text-gray-500'>
-                                    {operator.mainPresence === 'busy' &&
-                                    operator.conversations?.length ? (
-                                      <Badge rounded='full' variant='busy' size='small'>
-                                        <span className='mr-1.5'>Busy</span>
+                                    {operator.conversations?.length ? (
+                                      <Badge rounded='full' variant='busy'>
+                                        <span className='mr-1.5'>{operator.mainPresence}</span>
                                         {/* //// TODO format duration */}
                                         <span>{operator.conversations[0].duration}</span>
                                       </Badge>
@@ -437,10 +436,9 @@ const Operators: NextPage = () => {
                               {operator.name}
                             </span>
                             <span className='block truncate mt-1 text-sm font-medium text-gray-500 dark:text-gray-500'>
-                              {operator.mainPresence === 'busy' &&
-                              operator.conversations?.length ? (
+                              {operator.conversations?.length ? (
                                 <Badge rounded='full' variant='busy' size='small'>
-                                  <span className='mr-1.5'>Busy</span>
+                                  <span className='mr-1.5'>{operator.mainPresence}</span>
                                   {/* //// TODO format duration */}
                                   <span>{operator.conversations[0].duration}</span>
                                 </Badge>

--- a/pages/operators.tsx
+++ b/pages/operators.tsx
@@ -16,13 +16,13 @@ import {
   sortByOperatorStatus,
   UNAVAILABLE_STATUSES,
 } from '../lib/operators'
-import { isEmpty, debounce } from 'lodash'
+import { isEmpty, debounce, capitalize } from 'lodash'
 import { useSelector } from 'react-redux'
 import { RootState } from '../store'
 import { Filter, OperatorStatusBadge } from '../components/operators'
 import { sortByProperty } from '../lib/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faFilter, faHeadset } from '@fortawesome/free-solid-svg-icons'
+import { faChevronRight, faFilter, faHeadset } from '@fortawesome/free-solid-svg-icons'
 import { loadPreference } from '../lib/storage'
 
 //// use i18n where there is operator.mainPresence
@@ -60,8 +60,13 @@ const Operators: NextPage = () => {
   }
 
   const [sortByFilter, setSortByFilter]: any = useState('')
-  const updateSortFilter = (newSortBy: string) => {
+  const updateSort = (newSortBy: string) => {
     setSortByFilter(newSortBy)
+  }
+
+  const [layout, setLayout] = useState('')
+  const updateLayout = (newLayout: string) => {
+    setLayout(newLayout)
   }
 
   const applyFilters = (operators: any) => {
@@ -219,39 +224,14 @@ const Operators: NextPage = () => {
           updateTextFilter={debouncedUpdateTextFilter}
           updateGroupFilter={updateGroupFilter}
           updateStatusFilter={updateStatusFilter}
-          updateSortFilter={updateSortFilter}
+          updateSort={updateSort}
+          updateLayout={updateLayout}
         />
         {/* operators error */}
         {operatorsError && (
           <InlineNotification type='error' title={operatorsError}></InlineNotification>
         )}
-        <div className='mx-auto max-w-7xl py-8 text-center'>
-          {/* skeleton */}
-          {!isOperatorsLoaded && (
-            <div className='space-y-8 sm:space-y-12'>
-              <ul
-                role='list'
-                className='mx-auto grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-4 md:gap-x-6 lg:max-w-5xl lg:gap-x-8 lg:gap-y-12 xl:grid-cols-5'
-              >
-                {Array.from(Array(15)).map((e, index) => (
-                  <li key={index}>
-                    <div className='space-y-4'>
-                      {/* avatar skeleton */}
-                      <div className='animate-pulse rounded-full h-24 w-24 mx-auto bg-gray-300 dark:bg-gray-600'></div>
-                      <div className='space-y-2'>
-                        {/* name skeleton */}
-                        <div className='animate-pulse h-3 rounded bg-gray-300 dark:bg-gray-600'></div>
-                        {/* status skeleton */}
-                        <div>
-                          <div className='animate-pulse h-8 rounded-full bg-gray-300 dark:bg-gray-600'></div>
-                        </div>
-                      </div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+        <div className='mx-auto max-w-7xl text-center'>
           {/* empty state */}
           {isOperatorsLoaded && !operatorsError && isEmpty(operators) && (
             <EmptyState
@@ -276,54 +256,171 @@ const Operators: NextPage = () => {
               }
             />
           )}
-          {/* operators grid */}
-          {isOperatorsLoaded && !operatorsError && !isEmpty(filteredOperators) && (
-            <div className='space-y-8 sm:space-y-12'>
+          {/* standard layout skeleton */}
+          {layout === 'standard' && !isOperatorsLoaded && (
+            <div className='space-y-8 sm:space-y-12 py-8'>
               <ul
                 role='list'
                 className='mx-auto grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-4 md:gap-x-6 lg:max-w-5xl lg:gap-x-8 lg:gap-y-12 xl:grid-cols-5'
               >
-                {isOperatorsLoaded &&
-                  !isEmpty(filteredOperators) &&
-                  Object.keys(filteredOperators).map((key, index) => {
-                    const operator = filteredOperators[key]
-                    return (
-                      <li key={index}>
-                        <div className='space-y-4'>
-                          <Avatar
-                            src={operator.avatarBase64}
-                            placeholderType='person'
-                            size='extra_large'
-                            bordered
-                            star={operator.favorite}
-                            onClick={() => openShowOperatorDrawer(operator)}
-                            className='mx-auto cursor-pointer'
-                          />
-                          <div className='space-y-2'>
-                            <div className='text-xs font-medium lg:text-sm'>
-                              <h3
-                                className='cursor-pointer hover:underline'
-                                onClick={() => openShowOperatorDrawer(operator)}
-                              >
-                                {operator.name}
-                              </h3>
-                              <div className='mt-3'>
-                                <OperatorStatusBadge
-                                  operator={operator}
-                                  currentUsername={auth.username}
-                                  callEnabled={true}
-                                  onCall={callOperator}
-                                />
-                              </div>
-                            </div>
-                          </div>
+                {Array.from(Array(15)).map((e, index) => (
+                  <li key={index}>
+                    <div className='space-y-4'>
+                      {/* avatar skeleton */}
+                      <div className='animate-pulse rounded-full h-24 w-24 mx-auto bg-gray-300 dark:bg-gray-600'></div>
+                      <div className='space-y-2'>
+                        {/* name skeleton */}
+                        <div className='animate-pulse h-3 rounded bg-gray-300 dark:bg-gray-600'></div>
+                        {/* status skeleton */}
+                        <div>
+                          <div className='animate-pulse h-8 rounded-full bg-gray-300 dark:bg-gray-600'></div>
                         </div>
-                      </li>
-                    )
-                  })}
+                      </div>
+                    </div>
+                  </li>
+                ))}
               </ul>
             </div>
           )}
+          {/* standard layout operators */}
+          {layout === 'standard' &&
+            isOperatorsLoaded &&
+            !operatorsError &&
+            !isEmpty(filteredOperators) && (
+              <div className='space-y-8 sm:space-y-12 py-8'>
+                <ul
+                  role='list'
+                  className='mx-auto grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-4 md:gap-x-6 lg:max-w-5xl lg:gap-x-8 lg:gap-y-12 xl:grid-cols-5'
+                >
+                  {isOperatorsLoaded &&
+                    !isEmpty(filteredOperators) &&
+                    Object.keys(filteredOperators).map((key, index) => {
+                      const operator = filteredOperators[key]
+                      return (
+                        <li key={index}>
+                          <div className='space-y-4'>
+                            <Avatar
+                              src={operator.avatarBase64}
+                              placeholderType='person'
+                              size='extra_large'
+                              bordered
+                              star={operator.favorite}
+                              onClick={() => openShowOperatorDrawer(operator)}
+                              className='mx-auto cursor-pointer'
+                            />
+                            <div className='space-y-2'>
+                              <div className='text-xs font-medium lg:text-sm'>
+                                <h3
+                                  className='cursor-pointer hover:underline'
+                                  onClick={() => openShowOperatorDrawer(operator)}
+                                >
+                                  {operator.name}
+                                </h3>
+                                <div className='mt-3'>
+                                  <OperatorStatusBadge
+                                    operator={operator}
+                                    currentUsername={auth.username}
+                                    callEnabled={true}
+                                    onCall={callOperator}
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      )
+                    })}
+                </ul>
+              </div>
+            )}
+          {/* compact layout skeleton */}
+          {layout === 'compact' && !isOperatorsLoaded && (
+            <ul role='list' className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 2xl:grid-cols-3'>
+              {Array.from(Array(24)).map((e, index) => (
+                <li key={index}>
+                  <button
+                    type='button'
+                    className='group flex w-full items-center justify-between space-x-3 rounded-full border p-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 focus:ring-primary dark:focus:ring-primary cursor-default'
+                  >
+                    <div className='flex min-w-0 flex-1 items-center space-x-3'>
+                      <div className='block flex-shrink-0'>
+                        <div className='animate-pulse rounded-full h-10 w-10 mx-auto bg-gray-300 dark:bg-gray-600'></div>
+                      </div>
+                      <span className='block min-w-0 flex-1'>
+                        <div className='animate-pulse h-3 rounded bg-gray-300 dark:bg-gray-600 mb-2'></div>
+                        <div className='animate-pulse h-3 rounded bg-gray-300 dark:bg-gray-600'></div>
+                      </span>
+                    </div>
+                    <span className='inline-flex h-10 w-10 flex-shrink-0 items-center justify-center'>
+                      <FontAwesomeIcon
+                        icon={faChevronRight}
+                        className='h-3 w-3 text-gray-400 dark:text-gray-500'
+                        aria-hidden='true'
+                      />
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          {/* compact layout operators */}
+          {layout === 'compact' &&
+            isOperatorsLoaded &&
+            !operatorsError &&
+            !isEmpty(filteredOperators) && (
+              <ul
+                role='list'
+                className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 2xl:grid-cols-3'
+              >
+                {Object.keys(filteredOperators).map((key, index) => {
+                  const operator = filteredOperators[key]
+                  return (
+                    <li key={index}>
+                      <button
+                        type='button'
+                        onClick={() => openShowOperatorDrawer(operator)}
+                        className='group flex w-full items-center justify-between space-x-3 rounded-full border p-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 focus:ring-primary dark:focus:ring-primary'
+                      >
+                        <span className='flex min-w-0 flex-1 items-center space-x-3'>
+                          <span className='block flex-shrink-0'>
+                            <Avatar
+                              src={operator.avatarBase64}
+                              placeholderType='person'
+                              size='large'
+                              bordered
+                              status={operator.mainPresence}
+                              star={operator.favorite}
+                              onClick={() => openShowOperatorDrawer(operator)}
+                              className='mx-auto cursor-pointer'
+                            />
+                          </span>
+                          <span className='block min-w-0 flex-1'>
+                            <span className='block truncate text-sm font-medium text-gray-900 dark:text-gray-100'>
+                              {operator.name}
+                            </span>
+                            <span className='block truncate text-sm font-medium text-gray-500 dark:text-gray-500'>
+                              {/* //// TODO */}
+                              {operator.mainPresence === 'busy' ? (
+                                <span>Ongoing call information</span>
+                              ) : (
+                                <span>{capitalize(operator.mainPresence)}</span>
+                              )}
+                            </span>
+                          </span>
+                        </span>
+                        <span className='inline-flex h-10 w-10 flex-shrink-0 items-center justify-center'>
+                          <FontAwesomeIcon
+                            icon={faChevronRight}
+                            className='h-3 w-3 text-gray-400 dark:text-gray-500 cursor-pointer'
+                            aria-hidden='true'
+                          />
+                        </span>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
         </div>
       </div>
     </>

--- a/pages/operators.tsx
+++ b/pages/operators.tsx
@@ -3,7 +3,7 @@
 
 import type { NextPage } from 'next'
 import { useEffect, useMemo, useState } from 'react'
-import { Avatar, EmptyState, InlineNotification } from '../components/common'
+import { Avatar, Badge, EmptyState, InlineNotification } from '../components/common'
 import {
   AVAILABLE_STATUSES,
   callOperator,
@@ -16,7 +16,7 @@ import {
   sortByOperatorStatus,
   UNAVAILABLE_STATUSES,
 } from '../lib/operators'
-import { isEmpty, debounce, capitalize } from 'lodash'
+import { isEmpty, debounce } from 'lodash'
 import { useSelector } from 'react-redux'
 import { RootState } from '../store'
 import { Filter, OperatorStatusBadge } from '../components/operators'
@@ -341,14 +341,14 @@ const Operators: NextPage = () => {
                 <li key={index}>
                   <button
                     type='button'
-                    className='group flex w-full items-center justify-between space-x-3 rounded-full border p-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 focus:ring-primary dark:focus:ring-primary cursor-default'
+                    className='group flex w-full items-center justify-between space-x-3 rounded-lg border p-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 focus:ring-primary dark:focus:ring-primary cursor-default'
                   >
                     <div className='flex min-w-0 flex-1 items-center space-x-3'>
                       <div className='block flex-shrink-0'>
                         <div className='animate-pulse rounded-full h-10 w-10 mx-auto bg-gray-300 dark:bg-gray-600'></div>
                       </div>
                       <span className='block min-w-0 flex-1'>
-                        <div className='animate-pulse h-3 rounded bg-gray-300 dark:bg-gray-600 mb-2'></div>
+                        <div className='animate-pulse h-3 rounded bg-gray-300 dark:bg-gray-600 mb-3'></div>
                         <div className='animate-pulse h-3 rounded bg-gray-300 dark:bg-gray-600'></div>
                       </span>
                     </div>
@@ -380,7 +380,7 @@ const Operators: NextPage = () => {
                       <button
                         type='button'
                         onClick={() => openShowOperatorDrawer(operator)}
-                        className='group flex w-full items-center justify-between space-x-3 rounded-full border p-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 focus:ring-primary dark:focus:ring-primary'
+                        className='group flex w-full items-center justify-between space-x-3 rounded-lg border p-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 focus:ring-primary dark:focus:ring-primary'
                       >
                         <span className='flex min-w-0 flex-1 items-center space-x-3'>
                           <span className='block flex-shrink-0'>
@@ -389,7 +389,6 @@ const Operators: NextPage = () => {
                               placeholderType='person'
                               size='large'
                               bordered
-                              status={operator.mainPresence}
                               star={operator.favorite}
                               onClick={() => openShowOperatorDrawer(operator)}
                               className='mx-auto cursor-pointer'
@@ -399,12 +398,26 @@ const Operators: NextPage = () => {
                             <span className='block truncate text-sm font-medium text-gray-900 dark:text-gray-100'>
                               {operator.name}
                             </span>
-                            <span className='block truncate text-sm font-medium text-gray-500 dark:text-gray-500'>
-                              {/* //// TODO */}
+                            <span className='block truncate mt-1 text-sm font-medium text-gray-500 dark:text-gray-500'>
                               {operator.mainPresence === 'busy' ? (
-                                <span>Ongoing call information</span>
+                                <Badge
+                                  rounded='full'
+                                  variant='busy'
+                                  size='small'
+                                  className='cursor-not-allowed'
+                                >
+                                  {/* //// TODO retrieve call information*/}
+                                  <span className='mr-3'>Big Tech spa</span>
+                                  <span>00:07:35</span>
+                                </Badge>
                               ) : (
-                                <span>{capitalize(operator.mainPresence)}</span>
+                                <OperatorStatusBadge
+                                  operator={operator}
+                                  currentUsername={auth.username}
+                                  callEnabled={true}
+                                  onCall={callOperator}
+                                  size='small'
+                                />
                               )}
                             </span>
                           </span>

--- a/pages/phonebook.tsx
+++ b/pages/phonebook.tsx
@@ -58,7 +58,7 @@ const Phonebook: NextPage = () => {
   }
 
   const [sortBy, setSortBy]: any = useState('')
-  const updateSortFilter = (newSortBy: string) => {
+  const updateSort = (newSortBy: string) => {
     setSortBy(newSortBy)
     setPhonebookLoaded(false)
   }
@@ -135,7 +135,7 @@ const Phonebook: NextPage = () => {
         <Filter
           updateTextFilter={debouncedUpdateTextFilter}
           updateContactTypeFilter={updateContactTypeFilter}
-          updateSortFilter={updateSortFilter}
+          updateSort={updateSort}
         />
         <div className='overflow-hidden shadow sm:rounded-md bg-white dark:bg-gray-900'>
           <ul role='list' className='divide-y divide-gray-200 dark:divide-gray-700'>

--- a/stories/Avatar.stories.tsx
+++ b/stories/Avatar.stories.tsx
@@ -18,6 +18,7 @@ const meta = {
         'callforward',
         'busy',
         'incoming',
+        'ringing',
         'offline',
       ],
       type: 'select',

--- a/stories/Avatar.stories.tsx
+++ b/stories/Avatar.stories.tsx
@@ -44,7 +44,6 @@ Circular.args = {
   rounded: 'full',
   bordered: false,
   src: 'https://images.unsplash.com/photo-1567532939604-b6b5b0db2604?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-  unoptimized: true,
 }
 
 export const Rounded = Template.bind({})
@@ -52,7 +51,6 @@ Rounded.args = {
   rounded: 'base',
   bordered: false,
   src: 'https://images.unsplash.com/photo-1567532939604-b6b5b0db2604?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-  unoptimized: true,
 }
 
 export const WithStatus = Template.bind({})
@@ -60,7 +58,6 @@ WithStatus.args = {
   status: 'available',
   bordered: false,
   src: 'https://images.unsplash.com/photo-1567532939604-b6b5b0db2604?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-  unoptimized: true,
 }
 
 export const WithInitials = Template.bind({})
@@ -118,7 +115,6 @@ export const AvatarGroup: Story<AvatarProps> = (args) => (
 )
 AvatarGroup.args = {
   bordered: true,
-  unoptimized: true,
 }
 
 export const AvatarGroupReverse: Story = (args) => (
@@ -130,7 +126,6 @@ export const AvatarGroupReverse: Story = (args) => (
 )
 AvatarGroupReverse.args = {
   bordered: true,
-  unoptimized: true,
 }
 
 export const WithStar = Template.bind({})
@@ -138,5 +133,4 @@ WithStar.args = {
   star: true,
   bordered: false,
   src: 'https://images.unsplash.com/photo-1567532939604-b6b5b0db2604?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-  unoptimized: true,
 }

--- a/stories/Badge.stories.tsx
+++ b/stories/Badge.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
         'callforward',
         'busy',
         'incoming',
+        'ringing',
         'offline',
       ],
     },

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -18,7 +18,7 @@ const meta = {
       action: 'clicked',
     },
     variant: {
-      options: ['primary', 'secondary', 'white', 'danger'],
+      options: ['primary', 'secondary', 'white', 'ghost', 'danger'],
     },
   },
   parameters: {
@@ -47,6 +47,12 @@ export const White = Template.bind({})
 White.args = {
   ...Primary.args,
   variant: 'white',
+}
+
+export const Ghost = Template.bind({})
+Ghost.args = {
+  ...Primary.args,
+  variant: 'ghost',
 }
 
 export const Danger = Template.bind({})

--- a/stories/OperatorStatusBadge.stories.tsx
+++ b/stories/OperatorStatusBadge.stories.tsx
@@ -54,6 +54,7 @@ const cellphoneOperator = { ...onlineOperator, mainPresence: 'cellphone' }
 const callforwardOperator = { ...onlineOperator, mainPresence: 'callforward' }
 const voicemailOperator = { ...onlineOperator, mainPresence: 'voicemail' }
 const incomingOperator = { ...onlineOperator, mainPresence: 'incoming' }
+const ringingOperator = { ...onlineOperator, mainPresence: 'ringing' }
 const busyOperator = { ...onlineOperator, mainPresence: 'busy' }
 const dndOperator = { ...onlineOperator, mainPresence: 'dnd' }
 const offlineOperator = { ...onlineOperator, mainPresence: 'offline' }
@@ -85,6 +86,12 @@ Voicemail.args = {
 export const Incoming = Template.bind({})
 Incoming.args = {
   operator: incomingOperator,
+  currentUsername: 'test',
+}
+
+export const Ringing = Template.bind({})
+Ringing.args = {
+  operator: ringingOperator,
   currentUsername: 'test',
 }
 

--- a/stories/OperatorStatusBadge.stories.tsx
+++ b/stories/OperatorStatusBadge.stories.tsx
@@ -50,6 +50,14 @@ const onlineOperator = {
   group: 'Test group',
 }
 
+const defaultArgs = {
+  size: 'base',
+  callEnabled: false,
+  onCall: undefined,
+  currentUsername: 'test',
+  operator: onlineOperator,
+}
+
 const cellphoneOperator = { ...onlineOperator, mainPresence: 'cellphone' }
 const callforwardOperator = { ...onlineOperator, mainPresence: 'callforward' }
 const voicemailOperator = { ...onlineOperator, mainPresence: 'voicemail' }
@@ -59,56 +67,73 @@ const busyOperator = { ...onlineOperator, mainPresence: 'busy' }
 const dndOperator = { ...onlineOperator, mainPresence: 'dnd' }
 const offlineOperator = { ...onlineOperator, mainPresence: 'offline' }
 
-export const Online = Template.bind({})
-Online.args = {
+export const CallEnabled = Template.bind({})
+// @ts-ignore
+CallEnabled.args = {
+  ...defaultArgs,
+  callEnabled: true,
   operator: onlineOperator,
-  currentUsername: 'test',
+}
+
+export const Online = Template.bind({})
+// @ts-ignore
+Online.args = {
+  ...defaultArgs,
+  operator: onlineOperator,
 }
 
 export const Cellphone = Template.bind({})
+// @ts-ignore
 Cellphone.args = {
+  ...defaultArgs,
   operator: cellphoneOperator,
-  currentUsername: 'test',
 }
 
 export const Callforward = Template.bind({})
+// @ts-ignore
 Callforward.args = {
+  ...defaultArgs,
   operator: callforwardOperator,
-  currentUsername: 'test',
 }
 
 export const Voicemail = Template.bind({})
+// @ts-ignore
 Voicemail.args = {
+  ...defaultArgs,
   operator: voicemailOperator,
-  currentUsername: 'test',
 }
 
 export const Incoming = Template.bind({})
+// @ts-ignore
 Incoming.args = {
+  ...defaultArgs,
   operator: incomingOperator,
-  currentUsername: 'test',
 }
 
 export const Ringing = Template.bind({})
+// @ts-ignore
 Ringing.args = {
+  ...defaultArgs,
   operator: ringingOperator,
-  currentUsername: 'test',
 }
 
 export const Busy = Template.bind({})
+// @ts-ignore
 Busy.args = {
+  ...defaultArgs,
   operator: busyOperator,
-  currentUsername: 'test',
 }
 
 export const Dnd = Template.bind({})
+// @ts-ignore
 Dnd.args = {
+  ...defaultArgs,
   operator: dndOperator,
-  currentUsername: 'test',
 }
 
 export const Offline = Template.bind({})
+// @ts-ignore
 Offline.args = {
+  ...defaultArgs,
   operator: offlineOperator,
-  currentUsername: 'test',
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,14 +28,14 @@
   animation-duration: 1s;
 }
 
-.incoming-loader {
+.ringing-animation {
   width: 16px;
   height: 16px;
   display: inline-block;
   position: relative;
 }
-.incoming-loader::after,
-.incoming-loader::before {
+.ringing-animation::after,
+.ringing-animation::before {
   content: '';
   box-sizing: border-box;
   width: 16px;
@@ -45,13 +45,13 @@
   position: absolute;
   left: 0;
   top: 0;
-  animation: animIncomingLoader 1s linear infinite;
+  animation: ringingAnimation 1s linear infinite;
 }
-.incoming-loader::after {
+.ringing-animation::after {
   animation-delay: 0.5s;
 }
 
-@keyframes animIncomingLoader {
+@keyframes ringingAnimation {
   0% {
     transform: scale(0);
     opacity: 1;

--- a/theme/Theme.ts
+++ b/theme/Theme.ts
@@ -10,6 +10,8 @@ const theme = {
       'border border-transparent focus:ring-primaryLight bg-primaryLighter text-primaryDark hover:bg-primaryLighter dark:focus:ring-primaryDark dark:bg-primaryDarker dark:text-primaryLight dark:hover:bg-primaryDarker',
     white:
       'border shadow-sm border-gray-300 bg-white text-gray-700 hover:bg-gray-100 focus:ring-primaryLight dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus:ring-primaryDark',
+    ghost:
+      'border-gray-300 text-gray-700 hover:bg-gray-200 focus:ring-primaryLight dark:border-gray-600 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus:ring-primaryDark',
     danger:
       'border border-transparent focus:ring-red-500 bg-red-600 hover:bg-red-700 text-white dark:focus:ring-red-600 dark:bg-red-700 dark:hover:bg-red-800 dark:text-white',
     rounded: {

--- a/theme/Theme.ts
+++ b/theme/Theme.ts
@@ -134,10 +134,9 @@ const theme = {
     available: {
       badge: {
         base: 'bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100',
-        dot: 'bg-emerald-400 dark:bg-emerald-400',
       },
       avatar: {
-        dot: 'bg-green-500 dark:bg-green-500',
+        dot: 'bg-emerald-500 dark:bg-emerald-500',
       },
       card: {
         border: 'border-green-500 dark:border-green-500',
@@ -146,7 +145,6 @@ const theme = {
     online: {
       badge: {
         base: 'bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100',
-        dot: 'bg-emerald-400 dark:bg-emerald-400',
       },
       avatar: {
         dot: 'bg-emerald-500 dark:bg-emerald-500',
@@ -158,10 +156,9 @@ const theme = {
     dnd: {
       badge: {
         base: 'bg-red-200 text-red-900 dark:bg-red-900 dark:text-red-100',
-        dot: 'bg-gray-400 dark:bg-gray-400',
       },
       avatar: {
-        dot: 'bg-gray-900 dark:bg-gray-900',
+        dot: 'bg-red-500 dark:bg-red-500',
       },
       card: {
         border: 'border-gray-500 dark:border-green-500',
@@ -170,10 +167,9 @@ const theme = {
     voicemail: {
       badge: {
         base: 'bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100',
-        dot: 'bg-orange-400 dark:bg-orange-400',
       },
       avatar: {
-        dot: 'bg-orange-500 dark:bg-orange-500',
+        dot: 'bg-emerald-500 dark:bg-emerald-500',
       },
       card: {
         border: 'border-orange-500 dark:border-orange-500',
@@ -182,10 +178,9 @@ const theme = {
     cellphone: {
       badge: {
         base: 'bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100',
-        dot: 'bg-purple-400 dark:bg-purple-400',
       },
       avatar: {
-        dot: 'bg-purple-500 dark:bg-purple-500',
+        dot: 'bg-emerald-500 dark:bg-emerald-500',
       },
       card: {
         border: 'border-purple-500 dark:border-purple-500',
@@ -194,10 +189,9 @@ const theme = {
     callforward: {
       badge: {
         base: 'bg-emerald-200 text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100',
-        dot: 'bg-yellow-400 dark:bg-yellow-400',
       },
       avatar: {
-        dot: 'bg-yellow-400 dark:bg-yellow-400',
+        dot: 'bg-emerald-500 dark:bg-emerald-500',
       },
       card: {
         border: 'border-yellow-500 dark:border-yellow-500',
@@ -206,7 +200,6 @@ const theme = {
     busy: {
       badge: {
         base: 'bg-red-200 text-red-900 dark:bg-red-900 dark:text-red-100',
-        dot: 'bg-red-400 dark:bg-red-400',
       },
       avatar: {
         dot: 'bg-red-500 dark:bg-red-500',
@@ -218,10 +211,9 @@ const theme = {
     incoming: {
       badge: {
         base: 'bg-red-200 text-red-900 dark:bg-red-900 dark:text-red-100',
-        dot: 'bg-sky-400 dark:bg-sky-400',
       },
       avatar: {
-        dot: 'bg-sky-500 dark:bg-sky-500',
+        dot: 'bg-red-500 dark:bg-red-500',
       },
       card: {
         border: 'border-sky-500 dark:border-sky-500',
@@ -230,7 +222,6 @@ const theme = {
     offline: {
       badge: {
         base: 'bg-gray-300 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
-        dot: 'bg-gray-400 dark:bg-gray-400',
       },
       avatar: {
         dot: 'bg-gray-500 dark:bg-gray-500',

--- a/theme/Theme.ts
+++ b/theme/Theme.ts
@@ -41,7 +41,7 @@ const theme = {
     },
   },
   iconSwitch: {
-    base: 'transition-colors duration-200 transform focus:outline-none focus:ring-2 focus:z-20 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed inline-block cursor-pointer rounded-md shadow-sm text-gray-700 hover:bg-gray-200 focus:ring-primaryLight dark:text-gray-100 dark:hover:bg-gray-900 dark:focus:ring-primaryDark',
+    base: 'transition-colors duration-200 transform focus:outline-none focus:ring-2 focus:z-20 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed inline-block cursor-pointer rounded-md text-gray-700 hover:bg-gray-200 focus:ring-primaryLight dark:text-gray-100 dark:hover:bg-gray-900 dark:focus:ring-primaryDark',
     sizes: {
       small: 'px-1.5 py-1 text-xs',
       base: 'px-2 py-1 text-md',

--- a/theme/Theme.ts
+++ b/theme/Theme.ts
@@ -331,7 +331,7 @@ const theme = {
       base: 'block px-4 py-2 text-sm flex items-center gap-3 mt-1 mb-1 cursor-pointer',
       light: 'text-gray-700 dark:text-gray-300',
       active: 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100',
-      icon: 'h-4 w-4 flex text-gray-400 dark:text-gray-500',
+      icon: 'h-4 w-4 flex text-gray-500 dark:text-gray-400',
       centered: 'justify-center',
     },
     items: {

--- a/theme/Theme.ts
+++ b/theme/Theme.ts
@@ -219,6 +219,17 @@ const theme = {
         border: 'border-sky-500 dark:border-sky-500',
       },
     },
+    ringing: {
+      badge: {
+        base: 'bg-red-200 text-red-900 dark:bg-red-900 dark:text-red-100',
+      },
+      avatar: {
+        dot: 'bg-red-500 dark:bg-red-500',
+      },
+      card: {
+        border: 'border-sky-500 dark:border-sky-500',
+      },
+    },
     offline: {
       badge: {
         base: 'bg-gray-300 text-gray-700 dark:bg-gray-700 dark:text-gray-300',

--- a/theme/Types.ts
+++ b/theme/Types.ts
@@ -10,4 +10,5 @@ export type StatusTypes =
   | 'callforward'
   | 'busy'
   | 'incoming'
+  | 'ringing'
   | 'offline'


### PR DESCRIPTION
Changes to Operators page:
- Add compact layout
- Show current call info
- Show call duration in busy status badge
- Show text filter for group filter
- Add clear text filter button
- Add current call actions menu (book, hangup, spy...)
- Simplify operator status colors
- Add `ringing` operator status
- Minor fixes

Other changes:
- Show user avatar in top bar
- Button: add ghost variant and use it in kebab menus
- Rename `SideBar.tsx` to `SpeedDial.tsx`
- Minor fixes