### PR TITLE
Update phone-island to 0.7.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@headlessui/react": "^1.7.3",
-        "@nethesis/phone-island": "0.7.37",
         "@nethesis/nethesis-duotone-svg-icons": "github:nethesis/nethesis-icons#duotone",
         "@nethesis/nethesis-light-svg-icons": "github:nethesis/nethesis-icons#light",
         "@nethesis/nethesis-regular-svg-icons": "github:nethesis/nethesis-icons#regular",
         "@nethesis/nethesis-solid-svg-icons": "github:nethesis/nethesis-icons#solid",
         "@nethesis/nethesis-thin-svg-icons": "github:nethesis/nethesis-icons#thin",
+        "@nethesis/phone-island": "0.7.43",
         "@rematch/core": "^2.2.0",
         "@rematch/immer": "^2.1.3",
         "@types/crypto-js": "^4.1.1",
@@ -3522,6 +3522,7 @@
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
       "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -3823,17 +3824,21 @@
       }
     },
     "node_modules/@nethesis/phone-island": {
-      "version": "0.7.37",
-      "resolved": "https://registry.npmjs.org/@nethesis/phone-island/-/phone-island-0.7.37.tgz",
-      "integrity": "sha512-VixRejPNwvmRKBYTT7VbqFhca846ghS9cr4A+qsvgdGKS8GJuW1QcP/gCCPnBEuVccl5ZBhZ7gyFnmp5CKZkgw==",
+      "version": "0.7.43",
+      "resolved": "https://registry.npmjs.org/@nethesis/phone-island/-/phone-island-0.7.43.tgz",
+      "integrity": "sha512-PclM2Upu7962reYvFd3zeTp9gzpvEpLOZIrDBaAG19o+ZUr+jCcv2NWPXDpqQOaVbEVZ2taCP7JukBMWFjeYDg==",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
+        "@nethesis/nethesis-duotone-svg-icons": "github:nethesis/nethesis-icons#duotone",
+        "@nethesis/nethesis-light-svg-icons": "github:nethesis/nethesis-icons#light",
+        "@nethesis/nethesis-regular-svg-icons": "github:nethesis/nethesis-icons#regular",
+        "@nethesis/nethesis-solid-svg-icons": "github:nethesis/nethesis-icons#solid",
+        "@nethesis/nethesis-thin-svg-icons": "github:nethesis/nethesis-icons#thin",
         "@rematch/core": "^2.2.0",
         "@rematch/immer": "^2.1.3",
         "@swc/helpers": "^0.4.12",
         "@testing-library/jest-dom": "^5.11.4",
-        "@testing-library/react": "^11.1.0",
         "@testing-library/user-event": "^12.1.10",
         "framer-motion": "^7.6.19",
         "js-base64": "^3.7.3",
@@ -19020,59 +19025,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@testing-library/react": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
-      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "7.31.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^4.2.2",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.6",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^26.6.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-      "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
     "node_modules/@testing-library/user-event": {
       "version": "13.5.0",
       "dev": true,
@@ -19596,6 +19548,7 @@
       "version": "15.0.15",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
       "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
+      "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -43075,6 +43028,7 @@
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
       "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -43272,7 +43226,7 @@
     },
     "@nethesis/nethesis-duotone-svg-icons": {
       "version": "git+ssh://git@github.com/nethesis/nethesis-icons.git#4d45c0c4d1e68f9206664127c09dac53891969d1",
-      "from": "@nethesis/nethesis-duotone-svg-icons@https://github.com/nethesis/nethesis-icons#duotone",
+      "from": "@nethesis/nethesis-duotone-svg-icons@github:nethesis/nethesis-icons#duotone",
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.2.1"
       }
@@ -43306,17 +43260,21 @@
       }
     },
     "@nethesis/phone-island": {
-      "version": "0.7.37",
-      "resolved": "https://registry.npmjs.org/@nethesis/phone-island/-/phone-island-0.7.37.tgz",
-      "integrity": "sha512-VixRejPNwvmRKBYTT7VbqFhca846ghS9cr4A+qsvgdGKS8GJuW1QcP/gCCPnBEuVccl5ZBhZ7gyFnmp5CKZkgw==",
+      "version": "0.7.43",
+      "resolved": "https://registry.npmjs.org/@nethesis/phone-island/-/phone-island-0.7.43.tgz",
+      "integrity": "sha512-PclM2Upu7962reYvFd3zeTp9gzpvEpLOZIrDBaAG19o+ZUr+jCcv2NWPXDpqQOaVbEVZ2taCP7JukBMWFjeYDg==",
       "requires": {
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
+        "@nethesis/nethesis-duotone-svg-icons": "github:nethesis/nethesis-icons#duotone",
+        "@nethesis/nethesis-light-svg-icons": "github:nethesis/nethesis-icons#light",
+        "@nethesis/nethesis-regular-svg-icons": "github:nethesis/nethesis-icons#regular",
+        "@nethesis/nethesis-solid-svg-icons": "github:nethesis/nethesis-icons#solid",
+        "@nethesis/nethesis-thin-svg-icons": "github:nethesis/nethesis-icons#thin",
         "@rematch/core": "^2.2.0",
         "@rematch/immer": "^2.1.3",
         "@swc/helpers": "^0.4.12",
         "@testing-library/jest-dom": "^5.11.4",
-        "@testing-library/react": "^11.1.0",
         "@testing-library/user-event": "^12.1.10",
         "framer-motion": "^7.6.19",
         "js-base64": "^3.7.3",
@@ -54783,48 +54741,6 @@
         }
       }
     },
-    "@testing-library/react": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
-      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
-      },
-      "dependencies": {
-        "@testing-library/dom": {
-          "version": "7.31.2",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-          "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^4.2.0",
-            "aria-query": "^4.2.2",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.6",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^26.6.2"
-          }
-        },
-        "pretty-format": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-          "requires": {
-            "@jest/types": "^26.6.2",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^17.0.1"
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        }
-      }
-    },
     "@testing-library/user-event": {
       "version": "13.5.0",
       "dev": true,
@@ -55275,6 +55191,7 @@
       "version": "15.0.15",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
       "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
+      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@headlessui/react": "^1.7.3",
-    "@nethesis/phone-island": "0.7.37",
+    "@nethesis/phone-island": "0.7.43",
     "@nethesis/nethesis-duotone-svg-icons": "github:nethesis/nethesis-icons#duotone",
     "@nethesis/nethesis-light-svg-icons": "github:nethesis/nethesis-icons#light",
     "@nethesis/nethesis-regular-svg-icons": "github:nethesis/nethesis-icons#regular",


### PR DESCRIPTION
I removed axios inside phone-island because it isn't an essential package and brakes the integration with NextJs, now it's using fetch api instead and the version on nethvoice-cti can be updated.