### PR TITLE
Avoid styles conflicts with phone-island

### DIFF
--- a/components/island/Island.tsx
+++ b/components/island/Island.tsx
@@ -1,6 +1,7 @@
 // Copyright (C) 2023 Nethesis S.r.l.
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import '@nethesis/phone-island/dist/index.css'
 import { useState, useEffect } from 'react'
 import { PhoneIsland } from '@nethesis/phone-island'
 import { newIslandConfig } from '../../lib/settings'

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,6 @@
 // Copyright (C) 2023 Nethesis S.r.l.
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import '@nethesis/phone-island/dist/index.css'
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import { useState, useEffect } from 'react'


### PR DESCRIPTION
According to [nextjs documentation](https://nextjs.org/docs/basic-features/built-in-css-support#import-styles-from-node_modules) this is the right way to import the styles of a third party component avoiding conflicts. 