### PR TITLE
Disable swcMinify because of react-tooltip bug

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
+  swcMinify: false,
   output: 'standalone',
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2418,9 +2418,9 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-SQOeVbMwb1di+mVWWJLpsUTToKfqVNioXys011beCAhyOIFtS+GQoW4EQSneuxzmQKddExDwQ+X0hLl4lJJaSQ=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-qrcbyfnRVziRlB6IYwjCopYhO7Vud750JlJyuljruIXcPxr22y8zdckcJGsuOdnQ639uVD1tTXddrcH3t3QYIQ=="
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.2.3",
@@ -42420,9 +42420,9 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-SQOeVbMwb1di+mVWWJLpsUTToKfqVNioXys011beCAhyOIFtS+GQoW4EQSneuxzmQKddExDwQ+X0hLl4lJJaSQ=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-qrcbyfnRVziRlB6IYwjCopYhO7Vud750JlJyuljruIXcPxr22y8zdckcJGsuOdnQ639uVD1tTXddrcH3t3QYIQ=="
     },
     "@floating-ui/dom": {
       "version": "1.2.3",


### PR DESCRIPTION
`react-tooltip` version 5.10.x crashes the application in production environment.
Current workaround is to disable `swcMinify`.

See: https://github.com/ReactTooltip/react-tooltip/issues/972