### PR TITLE
Pass SIP_HOST and SIP_PORT to the phone-island

### DIFF
--- a/components/island/Island.tsx
+++ b/components/island/Island.tsx
@@ -29,6 +29,10 @@ export function Island() {
             auth_token: auth.token,
             sip_exten: webRTCExtension.id,
             sip_secret: webRTCExtension.secret,
+            // @ts-ignore
+            janus_host: window.CONFIG.JANUS_HOST,
+            // @ts-ignore
+            janus_port: window.CONFIG.JANUS_PORT,
           }),
         )
       }

--- a/components/island/Island.tsx
+++ b/components/island/Island.tsx
@@ -30,9 +30,9 @@ export function Island() {
             sip_exten: webRTCExtension.id,
             sip_secret: webRTCExtension.secret,
             // @ts-ignore
-            janus_host: window.CONFIG.JANUS_HOST,
+            sip_host: window.CONFIG.SIP_HOST,
             // @ts-ignore
-            janus_port: window.CONFIG.JANUS_PORT,
+            sip_port: window.CONFIG.SIP_PORT,
           }),
         )
       }

--- a/components/settings/Integrations.tsx
+++ b/components/settings/Integrations.tsx
@@ -46,6 +46,10 @@ export const Integrations = () => {
         auth_token: data.token,
         sip_exten: webRTCExtension.id,
         sip_secret: webRTCExtension.secret,
+        // @ts-ignore
+        janus_host: window.CONFIG.JANUS_HOST,
+        // @ts-ignore
+        janus_port: window.CONFIG.JANUS_PORT,
       })
       setConfig(config)
       setCopied(false)

--- a/components/settings/Integrations.tsx
+++ b/components/settings/Integrations.tsx
@@ -47,9 +47,9 @@ export const Integrations = () => {
         sip_exten: webRTCExtension.id,
         sip_secret: webRTCExtension.secret,
         // @ts-ignore
-        janus_host: window.CONFIG.JANUS_HOST,
+        sip_host: window.CONFIG.SIP_HOST,
         // @ts-ignore
-        janus_port: window.CONFIG.JANUS_PORT,
+        sip_port: window.CONFIG.SIP_PORT,
       })
       setConfig(config)
       setCopied(false)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,15 +50,9 @@ else
 EOF
 fi
 
-if [ -z $SIP_HOST ]; then
-  cat >> /app/public/config/config.production.js<<EOF
-  SIP_HOST: '127.0.0.1',
+cat >> /app/public/config/config.production.js<<EOF
+  SIP_HOST: '${SIP_HOST:-127.0.0.1}',
 EOF
-else
-  cat >> /app/public/config/config.production.js<<EOF
-  SIP_HOST: '$SIP_HOST',
-EOF
-fi
 
 if [ -z $SIP_PORT ]; then
   cat >> /app/public/config/config.production.js<<EOF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,15 +54,9 @@ cat >> /app/public/config/config.production.js<<EOF
   SIP_HOST: '${SIP_HOST:-127.0.0.1}',
 EOF
 
-if [ -z $SIP_PORT ]; then
-  cat >> /app/public/config/config.production.js<<EOF
-  SIP_PORT: '5060',
+cat >> /app/public/config/config.production.js<<EOF
+  SIP_PORT: '${SIP_PORT:-5060}',
 EOF
-else
-  cat >> /app/public/config/config.production.js<<EOF
-  SIP_PORT: '$SIP_PORT',
-EOF
-fi
 
 cat >> /app/public/config/config.production.js<<EOF
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,13 +50,21 @@ else
 EOF
 fi
 
-if [ -n $JANUS_HOST ]; then
+if [ -z $JANUS_HOST ]; then
+  cat >> /app/public/config/config.production.js<<EOF
+  JANUS_HOST: '127.0.0.1',
+EOF
+else
   cat >> /app/public/config/config.production.js<<EOF
   JANUS_HOST: '$JANUS_HOST',
 EOF
 fi
 
-if [ -n $JANUS_PORT ]; then
+if [ -z $JANUS_PORT ]; then
+  cat >> /app/public/config/config.production.js<<EOF
+  JANUS_PORT: '5060',
+EOF
+else
   cat >> /app/public/config/config.production.js<<EOF
   JANUS_PORT: '$JANUS_PORT',
 EOF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,23 +50,23 @@ else
 EOF
 fi
 
-if [ -z $JANUS_HOST ]; then
+if [ -z $SIP_HOST ]; then
   cat >> /app/public/config/config.production.js<<EOF
-  JANUS_HOST: '127.0.0.1',
+  SIP_HOST: '127.0.0.1',
 EOF
 else
   cat >> /app/public/config/config.production.js<<EOF
-  JANUS_HOST: '$JANUS_HOST',
+  SIP_HOST: '$SIP_HOST',
 EOF
 fi
 
-if [ -z $JANUS_PORT ]; then
+if [ -z $SIP_PORT ]; then
   cat >> /app/public/config/config.production.js<<EOF
-  JANUS_PORT: '5060',
+  SIP_PORT: '5060',
 EOF
 else
   cat >> /app/public/config/config.production.js<<EOF
-  JANUS_PORT: '$JANUS_PORT',
+  SIP_PORT: '$SIP_PORT',
 EOF
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,18 @@ else
 EOF
 fi
 
+if [ -n $JANUS_HOST ]; then
+  cat >> /app/public/config/config.production.js<<EOF
+  JANUS_HOST: '$JANUS_HOST',
+EOF
+fi
+
+if [ -n $JANUS_PORT ]; then
+  cat >> /app/public/config/config.production.js<<EOF
+  JANUS_PORT: '$JANUS_PORT',
+EOF
+fi
+
 cat >> /app/public/config/config.production.js<<EOF
 }
 

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -7,10 +7,20 @@ interface NewIslandConfigTypes {
   auth_token: string
   sip_exten: string
   sip_secret: string
+  janus_host: string
+  janus_port: string
 }
 
 export function newIslandConfig(obj: NewIslandConfigTypes): string {
-  return btoa(
-    `${obj.hostname}:${obj.username}:${obj.auth_token}:${obj.sip_exten}:${obj.sip_secret}`,
-  )
+  let configString: string = `${obj.hostname}:${obj.username}:${obj.auth_token}:${obj.sip_exten}:${obj.sip_secret}`
+  // Add janus_host to configuration string
+  if (obj.janus_host) {
+    configString = `${configString}:${obj.janus_host}`
+  }
+  // Add janus_port to configuration string
+  if (obj.janus_port) {
+    configString = `${configString}:${obj.janus_port}`
+  }
+  // Return the encoded string
+  return btoa(configString)
 }

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -7,13 +7,13 @@ interface NewIslandConfigTypes {
   auth_token: string
   sip_exten: string
   sip_secret: string
-  janus_host: string
-  janus_port: string
+  sip_host: string
+  sip_port: string
 }
 
 export function newIslandConfig(obj: NewIslandConfigTypes): string {
   // Return the encoded string
   return btoa(
-    `${obj.hostname}:${obj.username}:${obj.auth_token}:${obj.sip_exten}:${obj.sip_secret}:${obj.janus_host}:${obj.janus_port}`,
+    `${obj.hostname}:${obj.username}:${obj.auth_token}:${obj.sip_exten}:${obj.sip_secret}:${obj.sip_host}:${obj.sip_port}`,
   )
 }

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -12,15 +12,8 @@ interface NewIslandConfigTypes {
 }
 
 export function newIslandConfig(obj: NewIslandConfigTypes): string {
-  let configString: string = `${obj.hostname}:${obj.username}:${obj.auth_token}:${obj.sip_exten}:${obj.sip_secret}`
-  // Add janus_host to configuration string
-  if (obj.janus_host) {
-    configString = `${configString}:${obj.janus_host}`
-  }
-  // Add janus_port to configuration string
-  if (obj.janus_port) {
-    configString = `${configString}:${obj.janus_port}`
-  }
   // Return the encoded string
-  return btoa(configString)
+  return btoa(
+    `${obj.hostname}:${obj.username}:${obj.auth_token}:${obj.sip_exten}:${obj.sip_secret}:${obj.janus_host}:${obj.janus_port}`,
+  )
 }


### PR DESCRIPTION
Allow to connect the phone-island on non-standard SIP ports.
This is required for NS8.