### PR TITLE
fix(login): make username case insensitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
         "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
         "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-        "@nethesis/phone-island": "^0.13.1",
+        "@nethesis/phone-island": "^0.13.2",
         "@rematch/core": "^2.2.0",
         "@rematch/immer": "^2.1.3",
         "@rematch/select": "^3.1.2",
@@ -4220,9 +4220,9 @@
       }
     },
     "node_modules/@nethesis/phone-island": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@nethesis/phone-island/-/phone-island-0.13.1.tgz",
-      "integrity": "sha512-tMkQPFpV4vpcIydHyAagJyT5jMUUSTcAWsy/m7oLWJAMdIDmpedD+FmnYHBDvikTHRUWxVNVQcrLlhJo27pMrg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@nethesis/phone-island/-/phone-island-0.13.2.tgz",
+      "integrity": "sha512-etKF2J4SeQaTEedNVs3xExvJoy2wrwSdE4kFcD1lXC5l5i01qouzy66DQ+OJqIEg3/JvS7bkLYYdS5lFwPiWFA==",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
     "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
     "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-    "@nethesis/phone-island": "^0.13.1",
+    "@nethesis/phone-island": "^0.13.2",
     "@rematch/core": "^2.2.0",
     "@rematch/immer": "^2.1.3",
     "@rematch/select": "^3.1.2",

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -243,7 +243,7 @@ export default function Login() {
     setLoading(true)
 
     if (window !== undefined) {
-      const username = usernameRef?.current?.value
+      const username = usernameRef?.current?.value?.toLowerCase()
       const password = passwordRef?.current?.value
       setOnError(false)
 


### PR DESCRIPTION
During login CTI username is now sent to backend in lowercase. This is because CTI server always expects usernames in lowercase letters.

Ref:
- https://github.com/NethServer/dev/issues/7313
- https://github.com/NethServer/dev/issues/7364