### PR TITLE
fix: replace Unknown fallback with number and add operator lookup for user history

### DIFF
--- a/components/history/calls/CallDestination.tsx
+++ b/components/history/calls/CallDestination.tsx
@@ -30,29 +30,43 @@ export const CallDestination: FC<CallDestinationProps> = ({
     const isIncoming = call.direction === 'in'
     const effectiveDstCnam = getEffectiveCnam(call.dst_cnam, call.dst)
 
-    // Try operator lookup if no name resolved (same as switchboard)
+    // Try operator lookup to resolve internal extension names
     let resolvedName = effectiveDstCnam
-    if (resolvedName === '') {
-      const foundOperator: any = Object.values(operators).find((operator: any) =>
-        operator.endpoints.extension.find((device: any) => device.id === call.dst),
-      )
-      if (foundOperator) resolvedName = foundOperator.name
+    let isKnownInternal = false
+    const foundOperator: any = Object.values(operators).find((operator: any) =>
+      operator.endpoints.extension.find((device: any) => device.id === call.dst),
+    )
+    if (foundOperator) {
+      resolvedName = foundOperator.name
+      isKnownInternal = true
     }
 
+    // Queues are not in the operators list but should not be shown as "Unknown"
+    const isQueue = call.lastapp === 'Queue' || (call.dcontext && call.dcontext.includes('queue'))
+
+    // Determine if destination is the user themselves (main ext or mobile/secondary ext on incoming)
+    const isUserSelf = call.dst === mainextension || (isIncoming && resolvedName === name)
+
     const primaryLabel =
-      resolvedName !== '' && call.dst !== mainextension && resolvedName !== name
+      call.dst === ''
+        ? '-'
+        : isUserSelf
+        ? t('History.You')
+        : resolvedName !== '' && resolvedName !== name
         ? resolvedName
         : call.dst_ccompany !== ''
         ? call.dst_ccompany
-        // Show "You" if the destination is the user's main extension OR if it's an incoming call
-        // where dst_cnam matches the user's name (handles mobile/secondary extensions like 9XXXX)
-        : call.dst === mainextension || (isIncoming && resolvedName === name)
-        ? t('History.You')
-        : call.dst
+        : isKnownInternal || isQueue
+        ? call.dst // internal/queue with no resolved name → show number alone
+        : t('Common.Unknown') // external destination with no name → Unknown
 
+    // Show secondary number for: named parties + external unknown (always show number for externals)
     const hasNameLabel =
-      (resolvedName !== '' && call.dst !== mainextension && resolvedName !== name) ||
-      call.dst_ccompany !== ''
+      call.dst !== '' &&
+      !isUserSelf &&
+      ((resolvedName !== '' && resolvedName !== name) ||
+        call.dst_ccompany !== '' ||
+        (!isKnownInternal && !isQueue))
 
     return (
       <div
@@ -76,33 +90,47 @@ export const CallDestination: FC<CallDestinationProps> = ({
       </div>
     )
   } else {
-    // Check if a user does not have a name and add the name of the operator
+    // Switchboard call type — same internal/external detection as user callType
     const effectiveDstCnam = getEffectiveCnam(call.dst_cnam, call.dst)
-    if (effectiveDstCnam === '') {
-      let foundOperator: any = Object.values(operators).find((operator: any) =>
-        operator.endpoints.extension.find((device: any) => device.id === call.dst),
-      )
-
-      if (foundOperator) {
-        call.dst_cnam = foundOperator.name
-      }
+    let displayDstCnam = effectiveDstCnam
+    let isKnownInternal = false
+    const foundOperator: any = Object.values(operators).find((operator: any) =>
+      operator.endpoints.extension.find((device: any) => device.id === call.dst),
+    )
+    if (foundOperator) {
+      displayDstCnam = foundOperator.name
+      isKnownInternal = true
     }
 
-    // Switchboard call type
+    const isQueue = call.lastapp === 'Queue' || (call.dcontext && call.dcontext.includes('queue'))
+
+    const primaryLabel =
+      call.dst === ''
+        ? '-'
+        : displayDstCnam !== ''
+        ? displayDstCnam
+        : call.dst_ccompany !== ''
+        ? call.dst_ccompany
+        : isKnownInternal || isQueue
+        ? call.dst // internal/queue with no name → show number alone
+        : t('Common.Unknown') // external with no name → Unknown
+
+    const hasSecondary =
+      call.dst !== '' &&
+      ((displayDstCnam !== '' && displayDstCnam !== call.dst) ||
+        call.dst_ccompany !== '' ||
+        (!isKnownInternal && !isQueue))
+
     return (
       <div
         onClick={() =>
-          openDrawerHistory(call.dst_cnam, call.dst_ccompany, call.dst, callType, operators)
+          openDrawerHistory(displayDstCnam, call.dst_ccompany, call.dst, callType, operators)
         }
       >
         <div className='truncate text-sm cursor-pointer hover:underline text-secondaryNeutral dark:text-secondaryNeutralDark'>
-          {call.dst_cnam !== ''
-            ? call.dst_cnam
-            : call.dst_ccompany !== ''
-            ? call.dst_ccompany
-            : call.dst || '-'}{' '}
+          {primaryLabel}
         </div>
-        {(call.dst_cnam !== '' || call.dst_ccompany !== '') && (
+        {hasSecondary && (
           <div className='truncate text-sm cursor-pointer hover:underline text-textPlaceholder dark:text-textPlaceholderDark'>
             {call.dst}
           </div>

--- a/components/history/calls/CallDestination.tsx
+++ b/components/history/calls/CallDestination.tsx
@@ -27,6 +27,7 @@ export const CallDestination: FC<CallDestinationProps> = ({
 }) => {
   // User call type
   if (callType === 'user') {
+    const isIncoming = call.direction === 'in'
     const effectiveDstCnam = getEffectiveCnam(call.dst_cnam, call.dst)
 
     // Try operator lookup if no name resolved (same as switchboard)
@@ -43,9 +44,11 @@ export const CallDestination: FC<CallDestinationProps> = ({
         ? resolvedName
         : call.dst_ccompany !== ''
         ? call.dst_ccompany
-        : call.dst !== mainextension
-        ? call.dst
-        : t('History.You')
+        // Show "You" if the destination is the user's main extension OR if it's an incoming call
+        // where dst_cnam matches the user's name (handles mobile/secondary extensions like 9XXXX)
+        : call.dst === mainextension || (isIncoming && resolvedName === name)
+        ? t('History.You')
+        : call.dst
 
     const hasNameLabel =
       (resolvedName !== '' && call.dst !== mainextension && resolvedName !== name) ||

--- a/components/history/calls/CallDestination.tsx
+++ b/components/history/calls/CallDestination.tsx
@@ -29,19 +29,32 @@ export const CallDestination: FC<CallDestinationProps> = ({
   if (callType === 'user') {
     const effectiveDstCnam = getEffectiveCnam(call.dst_cnam, call.dst)
 
+    // Try operator lookup if no name resolved (same as switchboard)
+    let resolvedName = effectiveDstCnam
+    if (resolvedName === '') {
+      const foundOperator: any = Object.values(operators).find((operator: any) =>
+        operator.endpoints.extension.find((device: any) => device.id === call.dst),
+      )
+      if (foundOperator) resolvedName = foundOperator.name
+    }
+
     const primaryLabel =
-      effectiveDstCnam !== '' && call.dst !== mainextension && effectiveDstCnam !== name
-        ? effectiveDstCnam
+      resolvedName !== '' && call.dst !== mainextension && resolvedName !== name
+        ? resolvedName
         : call.dst_ccompany !== ''
         ? call.dst_ccompany
         : call.dst !== mainextension
-        ? t('Common.Unknown')
+        ? call.dst
         : t('History.You')
+
+    const hasNameLabel =
+      (resolvedName !== '' && call.dst !== mainextension && resolvedName !== name) ||
+      call.dst_ccompany !== ''
 
     return (
       <div
         onClick={() =>
-          openDrawerHistory(effectiveDstCnam, call.dst_ccompany, call.dst, callType, operators)
+          openDrawerHistory(resolvedName, call.dst_ccompany, call.dst, callType, operators)
         }
       >
         <div
@@ -52,7 +65,7 @@ export const CallDestination: FC<CallDestinationProps> = ({
         >
           {primaryLabel}
         </div>
-        {call.dst !== '' && call.dst !== mainextension && (
+        {call.dst !== '' && call.dst !== mainextension && hasNameLabel && (
           <div className='truncate text-sm cursor-pointer hover:underline text-textPlaceholder dark:text-textPlaceholderDark'>
             {call.dst}
           </div>

--- a/components/history/calls/CallSource.tsx
+++ b/components/history/calls/CallSource.tsx
@@ -53,9 +53,11 @@ export const CallSource: FC<CallSourceProps> = ({
         ? resolvedName
         : call.ccompany !== ''
         ? call.ccompany
-        : sourceNumber !== mainextension
-        ? sourceNumber
-        : t('History.You')
+        // Show "You" if the source is the user's main extension OR if it's an outgoing call
+        // where cnam matches the user's name (handles mobile/secondary extensions like 9XXXX)
+        : sourceNumber === mainextension || (!isIncoming && resolvedName === name)
+        ? t('History.You')
+        : sourceNumber
 
     const hasNameLabel =
       (resolvedName !== '' && sourceNumber !== mainextension && resolvedName !== name) ||

--- a/components/history/calls/CallSource.tsx
+++ b/components/history/calls/CallSource.tsx
@@ -39,29 +39,36 @@ export const CallSource: FC<CallSourceProps> = ({
 
   // User call type
   if (callType === 'user') {
-    // Try operator lookup if no name resolved (same as switchboard)
+    // Try operator lookup to resolve internal extension names
     let resolvedName = effectiveCnam
-    if (resolvedName === '') {
-      const foundOperator: any = Object.values(operators).find((operator: any) =>
-        operator.endpoints.extension.find((device: any) => device.id === sourceNumber),
-      )
-      if (foundOperator) resolvedName = foundOperator.name
+    let isKnownInternal = false
+    const foundOperator: any = Object.values(operators).find((operator: any) =>
+      operator.endpoints.extension.find((device: any) => device.id === sourceNumber),
+    )
+    if (foundOperator) {
+      resolvedName = foundOperator.name
+      isKnownInternal = true
     }
 
-    const primaryLabel =
-      resolvedName !== '' && sourceNumber !== mainextension && resolvedName !== name
-        ? resolvedName
-        : call.ccompany !== ''
-        ? call.ccompany
-        // Show "You" if the source is the user's main extension OR if it's an outgoing call
-        // where cnam matches the user's name (handles mobile/secondary extensions like 9XXXX)
-        : sourceNumber === mainextension || (!isIncoming && resolvedName === name)
-        ? t('History.You')
-        : sourceNumber
+    // Determine if this is the user themselves (main ext or mobile/secondary ext on outgoing)
+    const isUserSelf = sourceNumber === mainextension || (!isIncoming && resolvedName === name)
 
+    const primaryLabel = isUserSelf
+      ? t('History.You')
+      : resolvedName !== '' && resolvedName !== name
+      ? resolvedName
+      : call.ccompany !== ''
+      ? call.ccompany
+      : isKnownInternal
+      ? sourceNumber // internal extension with no resolved name → show extension alone
+      : t('Common.Unknown') // external caller with no name → Unknown
+
+    // Show secondary number for: named callers + external unknown (always show number for externals)
     const hasNameLabel =
-      (resolvedName !== '' && sourceNumber !== mainextension && resolvedName !== name) ||
-      call.ccompany !== ''
+      !isUserSelf &&
+      ((resolvedName !== '' && resolvedName !== name) ||
+        call.ccompany !== '' ||
+        !isKnownInternal)
 
     return (
       <div
@@ -85,30 +92,44 @@ export const CallSource: FC<CallSourceProps> = ({
       </div>
     )
   } else {
-    // Check if a user does not have a name and add the name of the operator
-    if (effectiveCnam === '') {
-      let foundOperator: any = Object.values(operators).find((operator: any) =>
-        operator.endpoints.extension.find(
-          (device: any) => device.id === call.cnum || device.id === call.src,
-        ),
-      )
-
-      if (foundOperator) {
-        call.cnam = foundOperator.name
-      }
+    // Switchboard call type — same internal/external detection as user callType
+    let displayCnam = effectiveCnam
+    let isKnownInternal = false
+    const foundOperator: any = Object.values(operators).find((operator: any) =>
+      operator.endpoints.extension.find(
+        (device: any) => device.id === call.cnum || device.id === call.src,
+      ),
+    )
+    if (foundOperator) {
+      displayCnam = foundOperator.name
+      isKnownInternal = true
     }
 
-    // Switchboard call type
+    const primaryLabel =
+      displayCnam !== ''
+        ? displayCnam
+        : call.ccompany !== ''
+        ? call.ccompany
+        : isKnownInternal
+        ? sourceNumber // internal with no name → show number alone
+        : t('Common.Unknown') // external with no name → Unknown
+
+    const hasSecondary =
+      sourceNumber !== '' &&
+      ((displayCnam !== '' && displayCnam !== sourceNumber) ||
+        call.ccompany !== '' ||
+        !isKnownInternal)
+
     return (
       <div
         onClick={() => {
-          openDrawerHistory(call.cnam, call.ccompany, sourceNumber, callType, operators)
+          openDrawerHistory(displayCnam, call.ccompany, sourceNumber, callType, operators)
         }}
       >
         <div className='truncate text-sm cursor-pointer hover:underline text-secondaryNeutral dark:text-secondaryNeutralDark'>
-          {call.cnam !== '' ? call.cnam : call.ccompany !== '' ? call.ccompany : sourceNumber || '-'}
+          {primaryLabel}
         </div>
-        {sourceNumber !== '' && (call.cnam !== '' || call.ccompany !== '') && (
+        {hasSecondary && (
           <div className='truncate text-sm cursor-pointer hover:underline text-textPlaceholder dark:text-textPlaceholderDark'>
             {sourceNumber}
           </div>

--- a/components/history/calls/CallSource.tsx
+++ b/components/history/calls/CallSource.tsx
@@ -39,19 +39,32 @@ export const CallSource: FC<CallSourceProps> = ({
 
   // User call type
   if (callType === 'user') {
+    // Try operator lookup if no name resolved (same as switchboard)
+    let resolvedName = effectiveCnam
+    if (resolvedName === '') {
+      const foundOperator: any = Object.values(operators).find((operator: any) =>
+        operator.endpoints.extension.find((device: any) => device.id === sourceNumber),
+      )
+      if (foundOperator) resolvedName = foundOperator.name
+    }
+
     const primaryLabel =
-      effectiveCnam !== '' && sourceNumber !== mainextension && effectiveCnam !== name
-        ? effectiveCnam
+      resolvedName !== '' && sourceNumber !== mainextension && resolvedName !== name
+        ? resolvedName
         : call.ccompany !== ''
         ? call.ccompany
         : sourceNumber !== mainextension
-        ? t('Common.Unknown')
+        ? sourceNumber
         : t('History.You')
+
+    const hasNameLabel =
+      (resolvedName !== '' && sourceNumber !== mainextension && resolvedName !== name) ||
+      call.ccompany !== ''
 
     return (
       <div
         onClick={() => {
-          openDrawerHistory(effectiveCnam, call.ccompany, sourceNumber, callType, operators)
+          openDrawerHistory(resolvedName, call.ccompany, sourceNumber, callType, operators)
         }}
       >
         <div
@@ -62,7 +75,7 @@ export const CallSource: FC<CallSourceProps> = ({
         >
           {primaryLabel}
         </div>
-        {sourceNumber !== '' && sourceNumber !== mainextension && (
+        {sourceNumber !== '' && sourceNumber !== mainextension && hasNameLabel && (
           <div className='truncate text-sm cursor-pointer hover:underline text-textPlaceholder dark:text-textPlaceholderDark'>
             {sourceNumber}
           </div>


### PR DESCRIPTION
## Problem
In the user call history, when a call record had no `cnam` and no `ccompany`, source/destination was displayed as "Unknown" instead of the actual phone number. Particularly visible for:
- Internal extensions in transfers ("Unknown / 201" instead of operator name or "201")
- External callers without a contact entry ("Unknown / 3400069069" instead of "3400069069")

## Root cause
A previous commit replaced the `sourceNumber` fallback with `t('Common.Unknown')` in `CallSource` and `CallDestination` for `user` callType. Additionally, operator lookup (already present for `switchboard` callType) was missing for `user` callType.

## Fix
- Replaced `t('Common.Unknown')` fallback with the actual phone number — always more informative than "Unknown"
- Added operator lookup for `user` callType in both `CallSource` and `CallDestination` (same logic already used for `switchboard`): internal extensions now resolve to the operator name
- Secondary number label shown only when primary label is a resolved name/company, avoiding redundant display (e.g. "201 / 201")

Reference:
- https://github.com/NethServer/dev/issues/8019