### PR TITLE
chore(qa): bump @nethesis/phone-island to 1.0.10-dev.3 (duplicate-number fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
         "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
         "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-        "@nethesis/phone-island": "^1.0.10",
+        "@nethesis/phone-island": "^1.0.10-dev.3",
         "@rematch/core": "^2.2.0",
         "@rematch/immer": "^2.1.3",
         "@rematch/select": "^3.1.2",
@@ -1461,9 +1461,9 @@
       }
     },
     "node_modules/@nethesis/phone-island": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@nethesis/phone-island/-/phone-island-1.0.10.tgz",
-      "integrity": "sha512-94aA8NJ1H8KrKj/u4kHEhQDCUcWF4aMqhKr5hxGbDJ0zpnpRjydrSJ8iigfi3OBOHXJeiXogZ/E9D44cdAjtyg==",
+      "version": "1.0.10-dev.3",
+      "resolved": "https://registry.npmjs.org/@nethesis/phone-island/-/phone-island-1.0.10-dev.3.tgz",
+      "integrity": "sha512-WuEMd+cEPZIF9z2bGmSOujUnU7GTcwpBvDnDcveVFULisvS0o9JicMep2dfrtwnZStFs2iAp/7tHByaaG/TUcQ==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.7.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@nethesis/nethesis-brands-svg-icons": "github:nethesis/Font-Awesome#ns-brands",
     "@nethesis/nethesis-light-svg-icons": "github:nethesis/Font-Awesome#ns-light",
     "@nethesis/nethesis-solid-svg-icons": "github:nethesis/Font-Awesome#ns-solid",
-    "@nethesis/phone-island": "^1.0.10",
+    "@nethesis/phone-island": "^1.0.10-dev.3",
     "@rematch/core": "^2.2.0",
     "@rematch/immer": "^2.1.3",
     "@rematch/select": "^3.1.2",


### PR DESCRIPTION
QA-only dependency bump to build a cti image embedding phone-island#250 (external number shown twice when not in the phonebook).

Bumps `@nethesis/phone-island` to `1.0.10-dev.3` (dev pre-release that contains the fix) and updates the lockfile.

## Test Case
> Setup: configure a trunk routed directly to an internal extension, so an external call lands on the extension with the external number as caller id.

1. Call from an external number NOT in the phonebook and expand the call view while ringing: the number appears only once.
2. Call from a contact in the phonebook: name as display name + number below it (unchanged).

⚠️ QA-only (dev pre-release) — **do not merge**; revert to the released phone-island version once phone-island#250 is published.

Reference:
- NethServer/dev#8048