### PR TITLE
refactor(history): call POST /history/statuses for call status

### DIFF
--- a/services/user.ts
+++ b/services/user.ts
@@ -112,7 +112,7 @@ export const checkSummaryList = async (
         ? { uniqueids: lookups as string[] }
         : { lookups: lookups as Array<{ uniqueid?: string; linkedid?: string }> }
     if (switchboard) body.switchboard = true
-    const res = await axios.post(`/summary/statuses`, body)
+    const res = await axios.post(`/history/statuses`, body)
     return res.data
   } catch (error: any) {
     const status = error?.response?.status


### PR DESCRIPTION
The middleware status endpoint moved from `/summary/statuses` to `/history/statuses` (it covers both transcription and summary and is consumed only by the History view). Updates the single consumer (`services/user.ts checkSummaryList`).

Pairs with nethcti-middleware#60. Must ship together.

## Test Case
1. Open History > Calls: rows with transcription/summary show the correct status/actions (unchanged).
2. While a summary is still processing, the badge updates within a few seconds without the list reloading.
3. Network tab: the status request goes to `POST /history/statuses` and returns 200.

Reference:
- NethServer/dev#8049